### PR TITLE
Fix hosted plugin block handling and make UI storage writes atomic (credit: Diego Garcia)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### DSP & Plugin Hosting
+* Fixed hosted plugins being fed stale audio when the host delivers a block smaller than the declared maximum (e.g. ASIO buffer sizes below 256). The plugin now sees exactly the frames the host provided instead of processing the previous block's tail.
+* Hosted plugins are now explicitly resumed after `prepareToPlay`, so plugins that gate processing on `isSuspended()` no longer load silently without affecting the audio.
+
+### Reliability
+* UI storage files (setlists, automation, preset folders/favourites/ratings) are now written atomically, so a crash or power loss mid-write can no longer truncate them.
+
 ## 1.5.0 (July 25, 2026)
 
 ### Performance, Presets & Settings

--- a/core/src/PluginController.cpp
+++ b/core/src/PluginController.cpp
@@ -14016,12 +14016,28 @@ void PluginController::SaveUiStorageJson(const std::string& filename, const nloh
     try
     {
         [[maybe_unused]] const auto ensuredUiStorageParent = mFileSystem.EnsureDirectory(path.parent_path());
-        std::ofstream ofs(path);
-        if (ofs.is_open())
+
+        // Write to a temp file first, then atomically rename over the real file,
+        // matching SaveAppSettings. A partial write here would corrupt setlists.json,
+        // automation.json or the preset metadata files and lose the user's data.
+        const auto tempPath = path.parent_path() / (path.filename().string() + ".tmp");
         {
+            std::ofstream ofs(tempPath);
+            if (!ofs.is_open())
+                return;
             ofs << payload.dump(2);
-            wrote = true;
         }
+
+        std::error_code ec;
+        std::filesystem::rename(tempPath, path, ec);
+        if (ec)
+        {
+            // rename failed (e.g. cross-device) – fall back to copy+delete
+            std::filesystem::copy_file(tempPath, path,
+                                       std::filesystem::copy_options::overwrite_existing, ec);
+            std::filesystem::remove(tempPath, ec);
+        }
+        wrote = !ec;
     }
     catch (const std::exception&) {}
 

--- a/juce/source/JuceHostedPluginEffect.cpp
+++ b/juce/source/JuceHostedPluginEffect.cpp
@@ -750,7 +750,17 @@ namespace guitarfx
 
         CopyInputToWorkBuffer (inputs, numSamples);
         mMidiBuffer.clear();
-        mPlugin->processBlock (mWorkBuffer, mMidiBuffer);
+
+        // Expose only numSamples frames to the plugin. mWorkBuffer is sized to the
+        // maximum block declared at prepareToPlay; when the host delivers a smaller
+        // real-time block (e.g. an ASIO buffer below 256) the tail beyond numSamples
+        // still holds the previous block's samples. Passing the whole buffer makes
+        // the plugin process that stale tail, corrupting its internal state.
+        juce::AudioBuffer<float> blockView (mWorkBuffer.getArrayOfWritePointers(),
+                                            mWorkBuffer.getNumChannels(),
+                                            numSamples);
+        mPlugin->processBlock (blockView, mMidiBuffer);
+
         CopyWorkBufferToOutputs (inputs, outputs, numSamples);
     }
 
@@ -1185,6 +1195,10 @@ namespace guitarfx
             const juce::SpinLock::ScopedLockType lock (mPluginProcessLock);
             mPlugin->setRateAndBufferSizeDetails (mSampleRate, mMaxBlockSize);
             mPlugin->prepareToPlay (mSampleRate, mMaxBlockSize);
+            // A host must resume the plugins it prepares. Without this, a plugin
+            // that gates its processing on isSuspended() loads without error but
+            // silently passes audio through unprocessed.
+            mPlugin->suspendProcessing (false);
             UpdateWorkBufferForPlugin();
         }
         ApplyPendingPluginState();


### PR DESCRIPTION
Three independent, self-contained fixes cherry-picked from a larger in-progress branch. Each stands on its own; none depend on the rest of that work.

## 1. Hosted plugin fed stale audio on small blocks

`mWorkBuffer` is sized to the **maximum** block declared at `prepareToPlay`, but `CopyInputToWorkBuffer` only fills `[0, numSamples)`. Passing the whole buffer to `processBlock` meant the hosted plugin processed the previous block's tail on every callback — advancing its internal state (delay lines, LFO phase, envelope followers) by `maxBlockSize` instead of `numSamples`, and feeding it stale samples.

This only reproduces when the host delivers blocks smaller than the declared maximum, which is why it surfaced with ASIO buffer sizes below 256. The fix wraps the buffer in a non-owning view of exactly `numSamples` frames.

## 2. Hosted plugins never resumed after prepare

A host is required to resume the plugins it prepares. Without `suspendProcessing(false)`, a plugin that gates its processing on `isSuspended()` loads without any error but passes audio through unprocessed.

## 3. UI storage writes were not atomic

`SaveUiStorageJson` truncated and rewrote in place, so a crash or power loss mid-write could corrupt `setlists.json`, `automation.json`, or the preset folder/favourite/rating files. Now writes to a temp file and renames — matching the `SaveAppSettings` idiom already used in the same file, including its cross-device `copy_file` fallback.

## Verification

- `core/src/PluginController.cpp` — compiles clean (MSVC, Debug), no new warnings.
- `juce/source/JuceHostedPluginEffect.cpp` — compiles clean (MSVC, Debug), no new warnings.
- JUCE APIs checked against the pinned submodule: `AudioBuffer(Type* const*, int, int)` ctor, `getArrayOfWritePointers()` return type, and `suspendProcessing(bool)` all match.

Not runtime-tested against a DAW — worth a smoke test with a hosted plugin at an ASIO buffer of 128 to confirm the reported symptom is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)