### PR TITLE
Add NAM oversampling that provably removes most of antialiasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements: x64 CPU with AVX2 support (circa late 2015+; use `build_windows.ba
 
 ## Features
 
-- Neural Amp Modeler DSP for amp/pedal captures
+- Neural Amp Modeler DSP for amp/pedal captures, with optional 2x–32x time-scaled oversampling
 - Flexible signal graph with arbitrary effect ordering and parallel paths
 - Preset management with category support and content-addressed resource deduplication
 - Remote preset search/download for community sharing
@@ -148,7 +148,7 @@ This repository depends on or vendors the following third-party libraries and SD
 
 - JUCE and the CLAP JUCE extensions in `juce/`
 - Microsoft WebView2 for the Windows WebView host path
-- NeuralAmpModelerCore and Eigen used by the NAM DSP stack in `core/`
+- NeuralAmpModelerCore, NAM-Oversampler AudioDSPTools, and Eigen used by the NAM DSP stack in `core/`
 - nlohmann/json, Signalsmith Audio linear/stretch, stftPitchShift, miniz, and the Wasmtime C API in the core CMake dependency setup
 - jszip, TypeScript, and Vitest in `core/ui/`
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ This repository depends on or vendors the following third-party libraries and SD
 - nlohmann/json, Signalsmith Audio linear/stretch, stftPitchShift, miniz, and the Wasmtime C API in the core CMake dependency setup
 - jszip, TypeScript, and Vitest in `core/ui/`
 
-Refer to the upstream LICENSE files and package manifests for the exact license terms of each dependency.
+See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md), the upstream LICENSE files,
+and package manifests for the exact license terms of each dependency.
 
 ## License
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,95 @@
+# Third-Party Notices
+
+Soundshed Guitar is licensed under AGPL-3.0. The following notices apply to
+third-party software used by the NAM oversampling integration. These notices
+do not alter the AGPL-3.0 licensing of Soundshed Guitar's original code.
+
+## NAM-Oversampler
+
+Design and implementation reference:
+https://github.com/DLC86/NAM-Oversampler
+
+Reference revision:
+`7d8df1be321d933b0bb4eaa6f93689a5910273a7`
+
+MIT License
+
+Copyright (c) 2022 Steven Atkinson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## NeuralAmpModelerCore
+
+Source dependency:
+https://github.com/DLC86/NeuralAmpModelerCore
+
+Pinned revision:
+`bea723b300e2dfe54f417c9e9f9d7f68b4a8f30d`
+
+MIT License
+
+Copyright (c) 2023 Steven Atkinson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## AudioDSPTools
+
+Source dependency:
+https://github.com/DLC86/AudioDSPTools
+
+Pinned revision:
+`63bdfc9db16cb45da8f1dcb3af4c572286753dde`
+
+MIT License
+
+Copyright (c) 2023 Steven Atkinson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -353,38 +353,30 @@ if(GUITARFX_CORE_FETCH_DEPS AND NOT TARGET NeuralAmpModelerCore AND NOT TARGET n
     set(NAM_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
     set(NAM_BUILD_TESTS OFF CACHE BOOL "" FORCE)
     FetchContent_Declare(NeuralAmpModelerCore
-        GIT_REPOSITORY https://github.com/sdatkinson/NeuralAmpModelerCore.git
-        GIT_TAG v0.5.4
-        CMAKE_ARGS -DNAM_BUILD_TOOLS=OFF -DNAM_BUILD_TESTS=OFF)
-    FetchContent_MakeAvailable(NeuralAmpModelerCore)
+        # Pin the exact NAM-Oversampler core revision.  This adds time-scaled
+        # temporal convolutions (SetTimeScale) while retaining the NAM API used
+        # by Soundshed Guitar.
+        GIT_REPOSITORY https://github.com/DLC86/NeuralAmpModelerCore.git
+        GIT_TAG bea723b300e2dfe54f417c9e9f9d7f68b4a8f30d)
+
+    # This fork's top-level project always adds its command-line tools.  Only
+    # populate the source here; the existing fallback below builds the NAM
+    # library without pulling those executables into plugin builds.
+    if(POLICY CMP0169)
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+    FetchContent_GetProperties(NeuralAmpModelerCore)
+    if(NOT neuralampmodelercore_POPULATED)
+        FetchContent_Populate(NeuralAmpModelerCore)
+    endif()
+    if(POLICY CMP0169)
+        cmake_policy(POP)
+    endif()
+
     FetchContent_GetProperties(NeuralAmpModelerCore SOURCE_DIR NAM_SOURCE_DIR BINARY_DIR NAM_BINARY_DIR)
     if(NOT DEFINED NeuralAmpModelerCore_SOURCE_DIR)
         set(NeuralAmpModelerCore_SOURCE_DIR "${NAM_SOURCE_DIR}" CACHE PATH "" FORCE)
-    endif()
-
-    if(MSVC)
-        # neuralampmodelercore/tools/CMakeLists.txt sets -Wno-error on NAM sources as a
-        # GCC/Clang workaround for an Eigen warning. That flag is invalid on MSVC (D8021).
-        # Clear it from the tools directory scope (requires CMake >= 3.18).
-        if(DEFINED NeuralAmpModelerCore_SOURCE_DIR)
-            foreach(_src
-                    "${NeuralAmpModelerCore_SOURCE_DIR}/NAM/dsp.cpp"
-                    "${NeuralAmpModelerCore_SOURCE_DIR}/NAM/conv1d.cpp")
-                if(EXISTS "${_src}")
-                    set_source_files_properties("${_src}"
-                        DIRECTORY "${NeuralAmpModelerCore_SOURCE_DIR}/tools"
-                        PROPERTIES COMPILE_FLAGS "")
-                endif()
-            endforeach()
-        endif()
-        # Exclude all NAM tool executables from the default build on MSVC.
-        # 'render' was added upstream after the original list was written.
-        foreach(_nam_tool benchmodel bench_a2_fast loadmodel render run_tests tools)
-            if(TARGET ${_nam_tool})
-                set_property(TARGET ${_nam_tool} PROPERTY EXCLUDE_FROM_ALL TRUE)
-                set_property(TARGET ${_nam_tool} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
-            endif()
-        endforeach()
     endif()
 
     if(DEFINED NeuralAmpModelerCore_SOURCE_DIR)
@@ -405,23 +397,6 @@ if(GUITARFX_CORE_FETCH_DEPS AND NOT TARGET NeuralAmpModelerCore AND NOT TARGET n
                 message(FATAL_ERROR "Eigen 5.0.1 is required by NeuralAmpModelerCore but could not be located.")
             endif()
         endif()
-
-        # v0.5.x moved WaveNet model/config parser implementation into
-        # NAM/wavenet/*.cpp. Ensure these sources are part of the NAM target so
-        # get_dsp() can resolve WaveNet architectures at runtime.
-        set(_nam_wavenet_sources
-            "${NeuralAmpModelerCore_SOURCE_DIR}/NAM/wavenet/model.cpp"
-            "${NeuralAmpModelerCore_SOURCE_DIR}/NAM/wavenet/slimmable.cpp"
-            "${NeuralAmpModelerCore_SOURCE_DIR}/NAM/wavenet/a2_fast.cpp")
-        foreach(_nam_target IN ITEMS NeuralAmpModelerCore nam)
-            if(TARGET ${_nam_target})
-                foreach(_nam_src IN LISTS _nam_wavenet_sources)
-                    if(EXISTS "${_nam_src}")
-                        target_sources(${_nam_target} PRIVATE "${_nam_src}")
-                    endif()
-                endforeach()
-            endif()
-        endforeach()
     endif()
 
     if(NOT TARGET NeuralAmpModelerCore AND NOT TARGET nam AND DEFINED NeuralAmpModelerCore_SOURCE_DIR)
@@ -443,6 +418,29 @@ if(GUITARFX_CORE_FETCH_DEPS AND NOT TARGET NeuralAmpModelerCore AND NOT TARGET n
             target_include_directories(NeuralAmpModelerCore PUBLIC
                 "${NeuralAmpModelerCore_SOURCE_DIR}/Dependencies/nlohmann")
         endif()
+    endif()
+endif()
+
+# Stateful anti-aliasing resampler used by NAM-Oversampler.  Populate it as a
+# header-only source dependency rather than adding its standalone tools project.
+if(GUITARFX_CORE_FETCH_DEPS)
+    include(FetchContent)
+    FetchContent_Declare(nam_oversampler_audio_dsp_tools
+        GIT_REPOSITORY https://github.com/DLC86/AudioDSPTools.git
+        GIT_TAG 63bdfc9db16cb45da8f1dcb3af4c572286753dde)
+
+    if(POLICY CMP0169)
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+
+    FetchContent_GetProperties(nam_oversampler_audio_dsp_tools)
+    if(NOT nam_oversampler_audio_dsp_tools_POPULATED)
+        FetchContent_Populate(nam_oversampler_audio_dsp_tools)
+    endif()
+
+    if(POLICY CMP0169)
+        cmake_policy(POP)
     endif()
 endif()
 
@@ -705,6 +703,11 @@ if(DEFINED NeuralAmpModelerCore_SOURCE_DIR)
             "${NeuralAmpModelerCore_SOURCE_DIR}/Dependencies/nlohmann"
         )
     endif()
+endif()
+
+if(DEFINED nam_oversampler_audio_dsp_tools_SOURCE_DIR)
+    target_include_directories(SoundshedGuitarCore PUBLIC
+        "${nam_oversampler_audio_dsp_tools_SOURCE_DIR}")
 endif()
 
 # Signalsmith headers

--- a/core/src/PluginController.cpp
+++ b/core/src/PluginController.cpp
@@ -78,7 +78,7 @@ namespace
     };
 
     constexpr const char* kJamYouTubeApiKeySettingKey = "jam.youtubeApiKey";
-    constexpr const char* kBundledJamYouTubeApiKey = "AIzaSyDs_H5FswLGwL0kjnBhd_EDV5eRM9D64sc";
+    constexpr const char* kBundledJamYouTubeApiKey = "";
     constexpr const char* kFactoryArchiveResourceProvider = "factory-archives";
     constexpr const char* kLocalResourceProvider = "local";
     constexpr const char* kLocalResourceStorageFolder = "local";
@@ -5755,7 +5755,7 @@ void PluginController::HandleUpdateSignalPathNodeParamRequest(const nlohmann::js
     }
     // Some parameters (e.g. the convolution low-latency toggle) change a node's
     // processing latency. Re-report total plugin latency so the host updates PDC.
-    if (paramKey == "lowLatency")
+    if (paramKey == "lowLatency" || paramKey == "oversampling" || paramKey == "antiAliasPhase")
         UpdateHostLatency();
     mActivePresetJson = mActivePreset ? PresetStorage::SerializeToJson(*mActivePreset) : "{}";
 }

--- a/core/src/dsp/effects/MultiModelNAMAmpEffect.h
+++ b/core/src/dsp/effects/MultiModelNAMAmpEffect.h
@@ -10,13 +10,13 @@
  */
 
 #include "dsp/EffectProcessor.h"
-#include "dsp/BlockSincResampler.h"
 #include "dsp/LevelTargets.h"
 #include "dsp/EffectRegistry.h"
 #include "dsp/EffectGuids.h"
 #include "dsp/NamModelCache.h"
 #include "dsp/RealtimeParallel.h"
 #include "dsp/effects/NAMSampleRate.h"
+#include "dsp/effects/NAMOversampling.h"
 #include "dsp/effects/NAMSlimmableSettings.h"
 #include "NAM/dsp.h"
 #include "NAM/get_dsp.h"
@@ -40,6 +40,7 @@ public:
   {
     mSampleRate = sampleRate;
     mMaxBlockSize = maxBlockSize;
+    mPrepared = true;
 
     mInputBufferL.resize(static_cast<size_t>(maxBlockSize));
     mInputBufferR.resize(static_cast<size_t>(maxBlockSize));
@@ -49,8 +50,9 @@ public:
     for (auto& model : mModels)
     {
       ResizeModelBuffers(model, maxBlockSize);
-      ResetModel(model, sampleRate, maxBlockSize);
     }
+
+    UpdateLatencyAlignment();
   }
 
   void Reset() override
@@ -64,6 +66,8 @@ public:
     std::fill(mInputBufferR.begin(), mInputBufferR.end(), 0.0f);
     std::fill(mDryBufferL.begin(), mDryBufferL.end(), 0.0f);
     std::fill(mDryBufferR.begin(), mDryBufferR.end(), 0.0f);
+    mDryDelayLeft.Reset();
+    mDryDelayRight.Reset();
   }
 
   void Process(float** inputs, float** outputs, int numSamples) override
@@ -119,10 +123,13 @@ public:
       mInputBufferR[i] *= inputGain;
     }
 
+    mDryDelayLeft.Process(mDryBufferL.data(), numSamples);
+    mDryDelayRight.Process(mDryBufferR.data(), numSamples);
+
     if (selection.upperIndex == selection.lowerIndex)
     {
       auto& model = mModels[selection.lowerIndex];
-      if (!model.resamplingActive && rtparallel::ShouldParallelizeStereoWork(numSamples))
+      if (rtparallel::ShouldParallelizeStereoWork(numSamples))
       {
         const bool ran = rtparallel::DualLaneExecutor::Instance().Run(
           [&]() { ProcessModel(model, mInputBufferR.data(), model.outputBufferR.data(), numSamples, 1); },
@@ -212,6 +219,8 @@ public:
       mInputBufferL[i] *= inputGain;
     }
 
+    mDryDelayLeft.Process(mDryBufferL.data(), numSamples);
+
     if (selection.upperIndex == selection.lowerIndex)
     {
       auto &model = mModels[selection.lowerIndex];
@@ -270,6 +279,24 @@ public:
     {
       mEnabled = value > 0.5;
     }
+    else if (key == "oversampling")
+    {
+      const int index = std::clamp(static_cast<int>(std::lround(value)), 0, kNamOversamplingMaxIndex);
+      if (index != mOversamplingIndex)
+      {
+        mOversamplingIndex = index;
+        ReconfigureModelProcessing();
+      }
+    }
+    else if (key == "antiAliasPhase")
+    {
+      const int index = std::clamp(static_cast<int>(std::lround(value)), 0, 2);
+      if (index != mAntiAliasPhaseIndex)
+      {
+        mAntiAliasPhaseIndex = index;
+        ReconfigureModelProcessing();
+      }
+    }
     else if (!key.empty())
     {
       mTargetParams[key] = value;
@@ -318,6 +345,10 @@ public:
       return mEnabled ? 1.0 : 0.0;
     if (key == "useCalibration")
       return mUseCalibration ? 1.0 : 0.0;
+    if (key == "oversampling")
+      return static_cast<double>(mOversamplingIndex);
+    if (key == "antiAliasPhase")
+      return static_cast<double>(mAntiAliasPhaseIndex);
     const auto it = mTargetParams.find(key);
     if (it != mTargetParams.end())
       return it->second;
@@ -329,6 +360,7 @@ public:
   {
     mModels.clear();
     mHasModelParameters = false;
+    UpdateLatencyAlignment();
     if (refs.empty() || paths.empty())
       return false;
 
@@ -365,7 +397,6 @@ public:
       }
 
       ResizeModelBuffers(instance, mMaxBlockSize);
-      ResetModel(instance, mSampleRate, mMaxBlockSize);
 
       mModels.push_back(std::move(instance));
     }
@@ -377,6 +408,7 @@ public:
       return a.parameterValue < b.parameterValue;
     });
 
+    UpdateLatencyAlignment();
     UpdateAutoGains(SelectBlendModels());
     return true;
   }
@@ -385,6 +417,7 @@ public:
 
   [[nodiscard]] std::string GetType() const override { return "amp_nam_blend"; }
   [[nodiscard]] std::string GetCategory() const override { return "amp"; }
+  [[nodiscard]] int GetLatencySamples() const override { return mLatencySamples; }
 
 private:
   struct ModelInstance
@@ -396,9 +429,6 @@ private:
 
     std::unique_ptr<::nam::DSP> fallbackLeft;
     std::unique_ptr<::nam::DSP> fallbackRight;
-    bool resamplingActive = false;
-    double processingSampleRate = 44100.0;
-    int maxProcessingBlockSize = 512;
 
     std::vector<float> outputBufferL;
     std::vector<float> outputBufferR;
@@ -407,8 +437,10 @@ private:
     std::vector<NAM_SAMPLE> fallbackOutputL;
     std::vector<NAM_SAMPLE> fallbackOutputR;
 
-    BlockSincResampler inputResampler;
-    BlockSincResampler outputResampler;
+    NamOversamplingProcessor oversamplingLeft;
+    NamOversamplingProcessor oversamplingRight;
+    NamDryDelay wetDelayLeft;
+    NamDryDelay wetDelayRight;
 
     std::optional<double> inputLevel;
     std::optional<double> outputLevel;
@@ -440,8 +472,14 @@ private:
   bool mHasModelParameters = false;
   bool mUseCalibration = true;
   bool mEnabled = true;
+  bool mPrepared = false;
   std::string mParameterId;
   std::uint64_t mLevelTargetsRevision = 0;
+  int mOversamplingIndex = 0;
+  int mAntiAliasPhaseIndex = 0;
+  int mLatencySamples = 0;
+  NamDryDelay mDryDelayLeft;
+  NamDryDelay mDryDelayRight;
 
   std::optional<double> mCalibrationInputLevel;
 
@@ -513,29 +551,24 @@ private:
 
   void ResizeModelBuffers(ModelInstance& instance, int maxBlockSize)
   {
-    instance.processingSampleRate = ResolveInstanceSampleRate(instance);
-    // Match NeuralAmpModelerPlugin behavior: resample on any SR mismatch.
-    instance.resamplingActive = NeedsNamRuntimeResampling(instance.processingSampleRate, mSampleRate);
-    instance.maxProcessingBlockSize = instance.resamplingActive
-      ? BlockSincResampler::ComputeMaxOutputFrameCount(maxBlockSize, mSampleRate, instance.processingSampleRate)
-      : maxBlockSize;
-    instance.maxProcessingBlockSize = std::max(1, instance.maxProcessingBlockSize);
+    const int hostBlockSize = std::max(1, maxBlockSize);
+    instance.outputBufferL.resize(static_cast<size_t>(hostBlockSize));
+    instance.outputBufferR.resize(static_cast<size_t>(hostBlockSize));
+    instance.fallbackInputL.resize(static_cast<size_t>(hostBlockSize));
+    instance.fallbackInputR.resize(static_cast<size_t>(hostBlockSize));
+    instance.fallbackOutputL.resize(static_cast<size_t>(hostBlockSize));
+    instance.fallbackOutputR.resize(static_cast<size_t>(hostBlockSize));
 
-    instance.outputBufferL.resize(static_cast<size_t>(maxBlockSize));
-    instance.outputBufferR.resize(static_cast<size_t>(maxBlockSize));
-    instance.fallbackInputL.resize(static_cast<size_t>(instance.maxProcessingBlockSize));
-    instance.fallbackInputR.resize(static_cast<size_t>(instance.maxProcessingBlockSize));
-    instance.fallbackOutputL.resize(static_cast<size_t>(instance.maxProcessingBlockSize));
-    instance.fallbackOutputR.resize(static_cast<size_t>(instance.maxProcessingBlockSize));
+    if (!mPrepared || !instance.fallbackLeft || !instance.fallbackRight)
+      return;
 
-    instance.inputResampler.Prepare(mSampleRate,
-                    instance.processingSampleRate,
-                    maxBlockSize,
-                    SampleRateConversionQuality::HighPerformance);
-    instance.outputResampler.Prepare(instance.processingSampleRate,
-                     mSampleRate,
-                     instance.maxProcessingBlockSize,
-                     SampleRateConversionQuality::HighPerformance);
+    const double modelSampleRate = ResolveInstanceSampleRate(instance);
+    const int factor = NamOversamplingFactorFromIndex(mOversamplingIndex);
+    const auto filterPhase = NamAntiAliasPhaseFromIndex(mAntiAliasPhaseIndex);
+    instance.oversamplingLeft.Prepare(
+      *instance.fallbackLeft, mSampleRate, modelSampleRate, hostBlockSize, factor, filterPhase);
+    instance.oversamplingRight.Prepare(
+      *instance.fallbackRight, mSampleRate, modelSampleRate, hostBlockSize, factor, filterPhase);
   }
 
   void ResetModel(ModelInstance& instance, double sampleRate, int maxBlockSize)
@@ -544,8 +577,10 @@ private:
     (void)maxBlockSize;
     if (instance.fallbackLeft && instance.fallbackRight)
     {
-      instance.fallbackLeft->Reset(instance.processingSampleRate, instance.maxProcessingBlockSize);
-      instance.fallbackRight->Reset(instance.processingSampleRate, instance.maxProcessingBlockSize);
+      instance.oversamplingLeft.Reset(*instance.fallbackLeft);
+      instance.oversamplingRight.Reset(*instance.fallbackRight);
+      instance.wetDelayLeft.Reset();
+      instance.wetDelayRight.Reset();
     }
   }
 
@@ -556,35 +591,18 @@ private:
       auto& fallbackInput = channel == 0 ? instance.fallbackInputL : instance.fallbackInputR;
       auto& fallbackOutput = channel == 0 ? instance.fallbackOutputL : instance.fallbackOutputR;
       auto* fallback = channel == 0 ? instance.fallbackLeft.get() : instance.fallbackRight.get();
-      int modelFrames = numSamples;
-      if (instance.resamplingActive)
+      auto& oversampling = channel == 0 ? instance.oversamplingLeft : instance.oversamplingRight;
+      auto& wetDelay = channel == 0 ? instance.wetDelayLeft : instance.wetDelayRight;
+      for (int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex)
       {
-        modelFrames = GetModelFrameCount(instance, numSamples);
-        instance.inputResampler.ProcessFixedOutput(input, numSamples, fallbackInput.data(), modelFrames);
+        fallbackInput[sampleIndex] = static_cast<NAM_SAMPLE>(input[sampleIndex]);
       }
-      else
+      oversampling.Process(*fallback, fallbackInput.data(), fallbackOutput.data(), numSamples);
+      for (int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex)
       {
-        for (int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex)
-        {
-          fallbackInput[sampleIndex] = static_cast<NAM_SAMPLE>(input[sampleIndex]);
-        }
+        output[sampleIndex] = static_cast<float>(fallbackOutput[sampleIndex]);
       }
-      NAM_SAMPLE* inputPtr = fallbackInput.data();
-      NAM_SAMPLE* outputPtr = fallbackOutput.data();
-      NAM_SAMPLE* inputPtrs[1] = { inputPtr };
-      NAM_SAMPLE* outputPtrs[1] = { outputPtr };
-      fallback->process(inputPtrs, outputPtrs, modelFrames);
-      if (instance.resamplingActive)
-      {
-        instance.outputResampler.ProcessFixedOutput(fallbackOutput.data(), modelFrames, output, numSamples);
-      }
-      else
-      {
-        for (int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex)
-        {
-          output[sampleIndex] = static_cast<float>(fallbackOutput[sampleIndex]);
-        }
-      }
+      wetDelay.Process(output, numSamples);
       return;
     }
 
@@ -857,10 +875,36 @@ private:
     return ResolveNamModelProcessingSampleRate(expectedSR, mSampleRate);
   }
 
-  int GetModelFrameCount(const ModelInstance& instance, int numSamples) const
+  void ReconfigureModelProcessing()
   {
-    int modelFrames = BlockSincResampler::ComputeOutputFrameCount(numSamples, mSampleRate, instance.processingSampleRate);
-    return std::clamp(modelFrames, 1, instance.maxProcessingBlockSize);
+    if (!mPrepared)
+      return;
+
+    for (auto& model : mModels)
+      ResizeModelBuffers(model, mMaxBlockSize);
+
+    UpdateLatencyAlignment();
+  }
+
+  void UpdateLatencyAlignment()
+  {
+    mLatencySamples = 0;
+    for (const auto& model : mModels)
+    {
+      mLatencySamples = std::max(mLatencySamples, model.oversamplingLeft.GetLatencySamples());
+      mLatencySamples = std::max(mLatencySamples, model.oversamplingRight.GetLatencySamples());
+    }
+
+    for (auto& model : mModels)
+    {
+      model.wetDelayLeft.Prepare(
+        mLatencySamples - model.oversamplingLeft.GetLatencySamples(), mMaxBlockSize);
+      model.wetDelayRight.Prepare(
+        mLatencySamples - model.oversamplingRight.GetLatencySamples(), mMaxBlockSize);
+    }
+
+    mDryDelayLeft.Prepare(mLatencySamples, mMaxBlockSize);
+    mDryDelayRight.Prepare(mLatencySamples, mMaxBlockSize);
   }
 };
 
@@ -879,7 +923,11 @@ inline void RegisterMultiModelNAMAmpEffect()
     {"inputGain", "Input", 0.0, -24.0, 24.0, "dB"},
     {"outputGain", "Output", 0.0, -24.0, 24.0, "dB"},
     {"mix", "Mix", 1.0, 0.0, 1.0, "amount", "Advanced", true},
-    {"useCalibration", "Use Calibration", 1.0, 0.0, 1.0, "toggle", "Advanced", true}
+    {"useCalibration", "Use Calibration", 1.0, 0.0, 1.0, "toggle", "Advanced", true},
+    {"oversampling", "Oversampling", 0.0, 0.0, 5.0, "enum", "Advanced", true, 1.0,
+      {"Off", "2x", "4x", "8x", "16x", "32x"}},
+    {"antiAliasPhase", "AA Filter", 0.0, 0.0, 2.0, "enum", "Advanced", true, 1.0,
+      {"Minimum Phase", "Linear Short", "Linear Long"}}
   };
 
   EffectRegistry::Instance().Register(info.type, info, []()

--- a/core/src/dsp/effects/NAMOversampling.h
+++ b/core/src/dsp/effects/NAMOversampling.h
@@ -1,0 +1,245 @@
+#pragma once
+
+#include "NAM/dsp.h"
+#include "dsp/ResamplingContainer/ResamplingContainer.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+namespace guitarfx
+{
+  inline constexpr int kNamOversamplingMaxIndex = 5;
+
+  [[nodiscard]] inline int NamOversamplingFactorFromIndex(double value)
+  {
+    const int index = std::clamp(static_cast<int>(std::llround(value)), 0, kNamOversamplingMaxIndex);
+    return 1 << index;
+  }
+
+  [[nodiscard]] inline int NamOversamplingIndexFromFactor(int factor)
+  {
+    int index = 0;
+    int normalized = std::max(1, factor);
+    while (normalized > 1 && index < kNamOversamplingMaxIndex)
+    {
+      normalized >>= 1;
+      ++index;
+    }
+    return index;
+  }
+
+  [[nodiscard]] inline dsp::EAntiAliasFilterPhase NamAntiAliasPhaseFromIndex(double value)
+  {
+    switch (std::clamp(static_cast<int>(std::llround(value)), 0, 2))
+    {
+      case 1:
+        return dsp::EAntiAliasFilterPhase::LinearCascadedFIRShort;
+      case 2:
+        return dsp::EAntiAliasFilterPhase::LinearCascadedFIRLong;
+      default:
+        return dsp::EAntiAliasFilterPhase::MinimumPhaseCascadedFIR;
+    }
+  }
+
+  [[nodiscard]] inline double ResolveNamOversampledRenderingRate(double modelSampleRate,
+                                                                  double hostSampleRate,
+                                                                  int factor)
+  {
+    if (modelSampleRate <= 0.0 || hostSampleRate <= 0.0)
+      return modelSampleRate;
+    if (factor <= 1)
+      return modelSampleRate;
+
+    const double requestedRate = hostSampleRate * static_cast<double>(factor);
+    const double timeScale = std::max(1.0, std::round(requestedRate / modelSampleRate));
+    return modelSampleRate * timeScale;
+  }
+
+  /**
+   * One mono NAM lane using the NAM-Oversampler processing model:
+   *
+   *   host audio -> stateful AA upsampler -> time-scaled NAM -> AA downsampler
+   *
+   * The model's temporal dilation is multiplied by the same integer scale used
+   * for its rendering rate, preserving the physical convolution timing.
+   */
+  class NamOversamplingProcessor
+  {
+  public:
+    void Prepare(::nam::DSP& model,
+                 double hostSampleRate,
+                 double modelSampleRate,
+                 int maxBlockSize,
+                 int factor,
+                 dsp::EAntiAliasFilterPhase filterPhase)
+    {
+      mHostSampleRate = hostSampleRate;
+      mModelSampleRate = modelSampleRate;
+      mMaxBlockSize = std::max(1, maxBlockSize);
+      const int oversamplingFactor = std::clamp(factor, 1, 32);
+      mFilterPhase = filterPhase;
+
+      mRenderingSampleRate = ResolveNamOversampledRenderingRate(
+        mModelSampleRate, mHostSampleRate, oversamplingFactor);
+      if (mRenderingSampleRate <= 0.0)
+        mRenderingSampleRate = mHostSampleRate;
+
+      mTimeScale = static_cast<int>(std::max(
+        1.0, std::round(mRenderingSampleRate / std::max(mModelSampleRate, 1.0))));
+      mMaxRenderingBlockSize = std::max(
+        1,
+        static_cast<int>(std::ceil(
+          static_cast<double>(mMaxBlockSize) * mRenderingSampleRate / std::max(mHostSampleRate, 1.0))) + 1);
+
+      mResamplingActive = std::abs(mRenderingSampleRate - mHostSampleRate) > 1.0e-6;
+      if (mResamplingActive)
+      {
+        mResampler = std::make_unique<dsp::ResamplingContainer<NAM_SAMPLE, 1, 32>>(
+          mRenderingSampleRate, mFilterPhase, mModelSampleRate);
+        mResampler->Reset(mHostSampleRate, mMaxBlockSize);
+        if (mFilterPhase == dsp::EAntiAliasFilterPhase::MinimumPhaseCascadedFIR
+            && mResampler->HasSingleProcessCallbackPerBlock())
+          PrimeResampler();
+      }
+      else
+      {
+        mResampler.reset();
+      }
+
+      model.SetTimeScale(mTimeScale);
+      model.Reset(mRenderingSampleRate, mMaxRenderingBlockSize);
+      mPrepared = true;
+    }
+
+    void Reset(::nam::DSP& model)
+    {
+      if (!mPrepared)
+        return;
+
+      if (mResampler)
+      {
+        mResampler->SetAntiAliasFilterPhase(mFilterPhase);
+        mResampler->Reset(mHostSampleRate, mMaxBlockSize);
+      }
+      model.SetTimeScale(mTimeScale);
+      model.Reset(mRenderingSampleRate, mMaxRenderingBlockSize);
+    }
+
+    void Process(::nam::DSP& model, NAM_SAMPLE* input, NAM_SAMPLE* output, int numFrames)
+    {
+      if (!input || !output || numFrames <= 0)
+        return;
+
+      NAM_SAMPLE* inputPointers[1] = {input};
+      NAM_SAMPLE* outputPointers[1] = {output};
+
+      if (!mResampler)
+      {
+        model.process(inputPointers, outputPointers, numFrames);
+        return;
+      }
+
+      mResampler->ProcessBlock(
+        inputPointers,
+        outputPointers,
+        numFrames,
+        [&model](NAM_SAMPLE** renderingInput, NAM_SAMPLE** renderingOutput, int renderingFrames)
+        {
+          model.process(renderingInput, renderingOutput, renderingFrames);
+        });
+    }
+
+    [[nodiscard]] int GetLatencySamples() const noexcept
+    {
+      return mResampler ? mResampler->GetLatency() : 0;
+    }
+
+    [[nodiscard]] double GetRenderingSampleRate() const noexcept { return mRenderingSampleRate; }
+    [[nodiscard]] int GetMaxRenderingBlockSize() const noexcept { return mMaxRenderingBlockSize; }
+    [[nodiscard]] int GetTimeScale() const noexcept { return mTimeScale; }
+    [[nodiscard]] bool IsResamplingActive() const noexcept { return mResamplingActive; }
+
+  private:
+    void PrimeResampler()
+    {
+      if (!mResampler)
+        return;
+
+      // The minimum-phase backend lazily creates one decimator state array on
+      // its first block. Exercise that path during Prepare(), then clear its
+      // state, so the audio-thread call is allocation-free from block one.
+      std::vector<NAM_SAMPLE> silence(static_cast<std::size_t>(mMaxBlockSize), static_cast<NAM_SAMPLE>(0.0));
+      std::vector<NAM_SAMPLE> discarded(static_cast<std::size_t>(mMaxBlockSize), static_cast<NAM_SAMPLE>(0.0));
+      NAM_SAMPLE* inputPointers[1] = {silence.data()};
+      NAM_SAMPLE* outputPointers[1] = {discarded.data()};
+      mResampler->ProcessBlock(
+        inputPointers,
+        outputPointers,
+        mMaxBlockSize,
+        [](NAM_SAMPLE** input, NAM_SAMPLE** output, int numFrames)
+        {
+          std::copy_n(input[0], numFrames, output[0]);
+        });
+      mResampler->Reset(mHostSampleRate, mMaxBlockSize);
+    }
+
+    std::unique_ptr<dsp::ResamplingContainer<NAM_SAMPLE, 1, 32>> mResampler;
+    double mHostSampleRate = 48000.0;
+    double mModelSampleRate = 48000.0;
+    double mRenderingSampleRate = 48000.0;
+    int mMaxBlockSize = 512;
+    int mMaxRenderingBlockSize = 512;
+    int mTimeScale = 1;
+    dsp::EAntiAliasFilterPhase mFilterPhase = dsp::EAntiAliasFilterPhase::MinimumPhaseCascadedFIR;
+    bool mResamplingActive = false;
+    bool mPrepared = false;
+  };
+
+  /** Allocation-free fixed delay used to align an effect's dry signal with a
+   * linear-phase oversampled wet path. Prepare() is called off the audio thread. */
+  class NamDryDelay
+  {
+  public:
+    void Prepare(int latencySamples, int maxBlockSize)
+    {
+      mLatencySamples = std::max(0, latencySamples);
+      const std::size_t capacity = static_cast<std::size_t>(mLatencySamples + std::max(1, maxBlockSize) + 1);
+      mBuffer.assign(capacity, 0.0f);
+      mWritePosition = 0;
+    }
+
+    void Reset()
+    {
+      std::fill(mBuffer.begin(), mBuffer.end(), 0.0f);
+      mWritePosition = 0;
+    }
+
+    void Process(float* samples, int numSamples)
+    {
+      if (!samples || numSamples <= 0 || mLatencySamples <= 0 || mBuffer.empty())
+        return;
+
+      for (int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex)
+      {
+        std::size_t readPosition =
+          mWritePosition + mBuffer.size() - static_cast<std::size_t>(mLatencySamples);
+        if (readPosition >= mBuffer.size())
+          readPosition -= mBuffer.size();
+        const float delayed = mBuffer[readPosition];
+        mBuffer[mWritePosition] = samples[sampleIndex];
+        samples[sampleIndex] = delayed;
+        ++mWritePosition;
+        if (mWritePosition == mBuffer.size())
+          mWritePosition = 0;
+      }
+    }
+
+  private:
+    std::vector<float> mBuffer;
+    std::size_t mWritePosition = 0;
+    int mLatencySamples = 0;
+  };
+} // namespace guitarfx

--- a/core/src/dsp/effects/OptimizedNAMAmpEffect.h
+++ b/core/src/dsp/effects/OptimizedNAMAmpEffect.h
@@ -9,13 +9,13 @@
  */
 
 #include "dsp/EffectProcessor.h"
-#include "dsp/BlockSincResampler.h"
 #include "dsp/LevelTargets.h"
 #include "dsp/EffectRegistry.h"
 #include "dsp/EffectGuids.h"
 #include "dsp/NamModelCache.h"
 #include "dsp/RealtimeParallel.h"
 #include "dsp/effects/NAMSampleRate.h"
+#include "dsp/effects/NAMOversampling.h"
 #include "dsp/effects/NAMSlimmableSettings.h"
 #include "NAM/dsp.h"
 #include "NAM/get_dsp.h"
@@ -160,20 +160,18 @@ public:
   void Reset() override
   {
     if (mModelLeft)
-      mModelLeft->Reset(mModelSampleRate, mMaxModelBlockSize);
+      mOversamplingLeft.Reset(*mModelLeft);
     if (mModelRight)
-      mModelRight->Reset(mModelSampleRate, mMaxModelBlockSize);
+      mOversamplingRight.Reset(*mModelRight);
 
     std::fill(mInputBufferL.begin(), mInputBufferL.end(), static_cast<NAM_SAMPLE>(0.0));
     std::fill(mInputBufferR.begin(), mInputBufferR.end(), static_cast<NAM_SAMPLE>(0.0));
     std::fill(mOutputBufferL.begin(), mOutputBufferL.end(), static_cast<NAM_SAMPLE>(0.0));
     std::fill(mOutputBufferR.begin(), mOutputBufferR.end(), static_cast<NAM_SAMPLE>(0.0));
-    std::fill(mModelInputBufferL.begin(), mModelInputBufferL.end(), static_cast<NAM_SAMPLE>(0.0));
-    std::fill(mModelInputBufferR.begin(), mModelInputBufferR.end(), static_cast<NAM_SAMPLE>(0.0));
-    std::fill(mModelOutputBufferL.begin(), mModelOutputBufferL.end(), static_cast<NAM_SAMPLE>(0.0));
-    std::fill(mModelOutputBufferR.begin(), mModelOutputBufferR.end(), static_cast<NAM_SAMPLE>(0.0));
     std::fill(mDryBufferL.begin(), mDryBufferL.end(), 0.0f);
     std::fill(mDryBufferR.begin(), mDryBufferR.end(), 0.0f);
+    mDryDelayLeft.Reset();
+    mDryDelayRight.Reset();
 
     for (int ch = 0; ch < 2; ++ch)
     {
@@ -221,6 +219,8 @@ public:
       const bool applyPostDcBlocker = gEnableNamPostDcBlocker;
 
       ProcessModels(numSamples);
+      mDryDelayLeft.Process(mDryBufferL.data(), numSamples);
+      mDryDelayRight.Process(mDryBufferR.data(), numSamples);
 
       const float outputGainF = static_cast<float>(mOutputGain);
 
@@ -315,6 +315,11 @@ public:
 
   [[nodiscard]] bool SupportsMonoProcessing() const override { return true; }
 
+  [[nodiscard]] int GetLatencySamples() const override
+  {
+    return std::max(mOversamplingLeft.GetLatencySamples(), mOversamplingRight.GetLatencySamples());
+  }
+
   void ProcessMono(float *input, float *output, int numSamples) override
   {
     EnsureLevelTargetsCurrent();
@@ -346,6 +351,7 @@ public:
       const bool applyPostDcBlocker = gEnableNamPostDcBlocker;
 
       ProcessModelMono(numSamples);
+      mDryDelayLeft.Process(mDryBufferL.data(), numSamples);
 
       const float outputGainF = static_cast<float>(mOutputGain);
 
@@ -449,6 +455,26 @@ public:
       mPresenceDb = std::clamp(value, -10.0, 10.0);
       UpdateToneStack();
     }
+    else if (key == "oversampling")
+    {
+      const int index = std::clamp(static_cast<int>(std::llround(value)), 0, kNamOversamplingMaxIndex);
+      if (index != mOversamplingIndex)
+      {
+        mOversamplingIndex = index;
+        mModelsNeedReset = true;
+        ConfigureModelProcessing();
+      }
+    }
+    else if (key == "antiAliasPhase")
+    {
+      const int index = std::clamp(static_cast<int>(std::llround(value)), 0, 2);
+      if (index != mAntiAliasPhaseIndex)
+      {
+        mAntiAliasPhaseIndex = index;
+        mModelsNeedReset = true;
+        ConfigureModelProcessing();
+      }
+    }
     else if (key == "enabled")
     {
       mEnabled = value > 0.5;
@@ -487,6 +513,10 @@ public:
       return mTrebleDb;
     if (key == "presence")
       return mPresenceDb;
+    if (key == "oversampling")
+      return static_cast<double>(mOversamplingIndex);
+    if (key == "antiAliasPhase")
+      return static_cast<double>(mAntiAliasPhaseIndex);
     if (key == "enabled")
       return mEnabled ? 1.0 : 0.0;
     if (key == "useCalibration")
@@ -596,7 +626,7 @@ private:
   std::unique_ptr<::nam::DSP> mModelRight;
 
   std::filesystem::path mModelPath;
-  bool mResamplingActive = false;
+  double mBaseModelSampleRate = 44100.0;
   double mModelSampleRate = 44100.0;
   int mMaxModelBlockSize = 512;
 
@@ -613,17 +643,16 @@ private:
   std::vector<NAM_SAMPLE> mInputBufferR;
   std::vector<NAM_SAMPLE> mOutputBufferL;
   std::vector<NAM_SAMPLE> mOutputBufferR;
-  // Model-domain buffers, used only when runtime resampling is active.
-  std::vector<NAM_SAMPLE> mModelInputBufferL;
-  std::vector<NAM_SAMPLE> mModelInputBufferR;
-  std::vector<NAM_SAMPLE> mModelOutputBufferL;
-  std::vector<NAM_SAMPLE> mModelOutputBufferR;
   // Dry signal kept as float for the tone/mix stage.
   std::vector<float> mDryBufferL;
   std::vector<float> mDryBufferR;
 
-  BlockSincResampler mInputResampler;
-  BlockSincResampler mOutputResampler;
+  NamOversamplingProcessor mOversamplingLeft;
+  NamOversamplingProcessor mOversamplingRight;
+  NamDryDelay mDryDelayLeft;
+  NamDryDelay mDryDelayRight;
+  int mOversamplingIndex = 0;
+  int mAntiAliasPhaseIndex = 0;
 
   double mUserInputGain = 1.0;
   double mUserOutputGain = 1.0;
@@ -739,21 +768,14 @@ private:
 
   void ConfigureModelProcessing()
   {
-    mModelSampleRate = ResolveModelSampleRate();
-    // Match NeuralAmpModelerPlugin behavior: resample on any SR mismatch.
-    mResamplingActive = NeedsNamRuntimeResampling(mModelSampleRate, mSampleRate);
-    mMaxModelBlockSize = mResamplingActive
-      ? BlockSincResampler::ComputeMaxOutputFrameCount(mMaxBlockSize, mSampleRate, mModelSampleRate)
-      : mMaxBlockSize;
-    mMaxModelBlockSize = std::max(1, mMaxModelBlockSize);
+    mBaseModelSampleRate = ResolveModelSampleRate();
+    const int factor = NamOversamplingFactorFromIndex(mOversamplingIndex);
+    mModelSampleRate = ResolveNamOversampledRenderingRate(mBaseModelSampleRate, mSampleRate, factor);
+    mMaxModelBlockSize = std::max(
+      1,
+      static_cast<int>(std::ceil(
+        static_cast<double>(mMaxBlockSize) * mModelSampleRate / std::max(mSampleRate, 1.0))) + 1);
 
-    mModelInputBufferL.resize(static_cast<size_t>(mMaxModelBlockSize));
-    mModelInputBufferR.resize(static_cast<size_t>(mMaxModelBlockSize));
-    mModelOutputBufferL.resize(static_cast<size_t>(mMaxModelBlockSize));
-    mModelOutputBufferR.resize(static_cast<size_t>(mMaxModelBlockSize));
-
-    mInputResampler.Prepare(mSampleRate, mModelSampleRate, mMaxBlockSize, SampleRateConversionQuality::HighPerformance);
-    mOutputResampler.Prepare(mModelSampleRate, mSampleRate, mMaxModelBlockSize, SampleRateConversionQuality::HighPerformance);
     mPostDcBlocker[0].SetHighPass(kNamPostDcBlockerFrequencyHz, kNamPostDcBlockerQ, mSampleRate);
     mPostDcBlocker[1].SetHighPass(kNamPostDcBlockerFrequencyHz, kNamPostDcBlockerQ, mSampleRate);
 
@@ -787,107 +809,83 @@ private:
     {
       auto right = std::async(std::launch::async, [this]()
       {
-        mModelRight->Reset(mModelSampleRate, mMaxModelBlockSize);
+        mOversamplingRight.Prepare(
+          *mModelRight,
+          mSampleRate,
+          mBaseModelSampleRate,
+          mMaxBlockSize,
+          NamOversamplingFactorFromIndex(mOversamplingIndex),
+          NamAntiAliasPhaseFromIndex(mAntiAliasPhaseIndex));
       });
-      mModelLeft->Reset(mModelSampleRate, mMaxModelBlockSize);
+      mOversamplingLeft.Prepare(
+        *mModelLeft,
+        mSampleRate,
+        mBaseModelSampleRate,
+        mMaxBlockSize,
+        NamOversamplingFactorFromIndex(mOversamplingIndex),
+        NamAntiAliasPhaseFromIndex(mAntiAliasPhaseIndex));
       right.get();
     }
     else if (mModelLeft)
     {
-      mModelLeft->Reset(mModelSampleRate, mMaxModelBlockSize);
+      mOversamplingLeft.Prepare(
+        *mModelLeft,
+        mSampleRate,
+        mBaseModelSampleRate,
+        mMaxBlockSize,
+        NamOversamplingFactorFromIndex(mOversamplingIndex),
+        NamAntiAliasPhaseFromIndex(mAntiAliasPhaseIndex));
     }
     else if (mModelRight)
     {
-      mModelRight->Reset(mModelSampleRate, mMaxModelBlockSize);
+      mOversamplingRight.Prepare(
+        *mModelRight,
+        mSampleRate,
+        mBaseModelSampleRate,
+        mMaxBlockSize,
+        NamOversamplingFactorFromIndex(mOversamplingIndex),
+        NamAntiAliasPhaseFromIndex(mAntiAliasPhaseIndex));
     }
+
+    const int latency = GetLatencySamples();
+    mDryDelayLeft.Prepare(latency, mMaxBlockSize);
+    mDryDelayRight.Prepare(latency, mMaxBlockSize);
 
     mResetModelSampleRate = mModelSampleRate;
     mResetModelBlockSize = mMaxModelBlockSize;
     mModelsNeedReset = false;
   }
 
-  [[nodiscard]] int GetModelFrameCount(int numSamples) const
-  {
-    int modelFrames = BlockSincResampler::ComputeOutputFrameCount(numSamples, mSampleRate, mModelSampleRate);
-    return std::clamp(modelFrames, 1, mMaxModelBlockSize);
-  }
-
   void ProcessModels(int numSamples)
   {
-    auto processLeft = [&](int frames)
-    {
-      NAM_SAMPLE* in = mResamplingActive ? mModelInputBufferL.data() : mInputBufferL.data();
-      NAM_SAMPLE* out = mResamplingActive ? mModelOutputBufferL.data() : mOutputBufferL.data();
-      NAM_SAMPLE* inputPtrs[1] = { in };
-      NAM_SAMPLE* outputPtrs[1] = { out };
-      mModelLeft->process(inputPtrs, outputPtrs, frames);
-    };
-
-    auto processRight = [&](int frames)
-    {
-      NAM_SAMPLE* in = mResamplingActive ? mModelInputBufferR.data() : mInputBufferR.data();
-      NAM_SAMPLE* out = mResamplingActive ? mModelOutputBufferR.data() : mOutputBufferR.data();
-      NAM_SAMPLE* inputPtrs[1] = { in };
-      NAM_SAMPLE* outputPtrs[1] = { out };
-      mModelRight->process(inputPtrs, outputPtrs, frames);
-    };
-
-    if (!mResamplingActive)
-    {
-      bool ranParallel = false;
-      if (rtparallel::ShouldParallelizeStereoWork(numSamples))
-      {
-        ranParallel = rtparallel::DualLaneExecutor::Instance().Run(
-          [&]() { processRight(numSamples); },
-          [&]() { processLeft(numSamples); });
-      }
-      if (!ranParallel)
-      {
-        processLeft(numSamples);
-        processRight(numSamples);
-      }
-      return;
-    }
-
-    const int modelFrames = GetModelFrameCount(numSamples);
-    mInputResampler.ProcessFixedOutput(mInputBufferL.data(), numSamples, mModelInputBufferL.data(), modelFrames);
-    mInputResampler.ProcessFixedOutput(mInputBufferR.data(), numSamples, mModelInputBufferR.data(), modelFrames);
-
     bool ranParallel = false;
-    if (rtparallel::ShouldParallelizeStereoWork(modelFrames))
+    if (rtparallel::ShouldParallelizeStereoWork(numSamples))
     {
       ranParallel = rtparallel::DualLaneExecutor::Instance().Run(
-        [&]() { processRight(modelFrames); },
-        [&]() { processLeft(modelFrames); });
+        [&]()
+        {
+          mOversamplingRight.Process(
+            *mModelRight, mInputBufferR.data(), mOutputBufferR.data(), numSamples);
+        },
+        [&]()
+        {
+          mOversamplingLeft.Process(
+            *mModelLeft, mInputBufferL.data(), mOutputBufferL.data(), numSamples);
+        });
     }
     if (!ranParallel)
     {
-      processLeft(modelFrames);
-      processRight(modelFrames);
+      mOversamplingLeft.Process(
+        *mModelLeft, mInputBufferL.data(), mOutputBufferL.data(), numSamples);
+      mOversamplingRight.Process(
+        *mModelRight, mInputBufferR.data(), mOutputBufferR.data(), numSamples);
     }
-
-    mOutputResampler.ProcessFixedOutput(mModelOutputBufferL.data(), modelFrames, mOutputBufferL.data(), numSamples);
-    mOutputResampler.ProcessFixedOutput(mModelOutputBufferR.data(), modelFrames, mOutputBufferR.data(), numSamples);
   }
 
   void ProcessModelMono(int numSamples)
   {
-    if (!mResamplingActive)
-    {
-      NAM_SAMPLE* inputPtrs[1] = { mInputBufferL.data() };
-      NAM_SAMPLE* outputPtrs[1] = { mOutputBufferL.data() };
-      mModelLeft->process(inputPtrs, outputPtrs, numSamples);
-      return;
-    }
-
-    const int modelFrames = GetModelFrameCount(numSamples);
-    mInputResampler.ProcessFixedOutput(mInputBufferL.data(), numSamples, mModelInputBufferL.data(), modelFrames);
-
-    NAM_SAMPLE* inputPtrs[1] = { mModelInputBufferL.data() };
-    NAM_SAMPLE* outputPtrs[1] = { mModelOutputBufferL.data() };
-    mModelLeft->process(inputPtrs, outputPtrs, modelFrames);
-
-    mOutputResampler.ProcessFixedOutput(mModelOutputBufferL.data(), modelFrames, mOutputBufferL.data(), numSamples);
+    mOversamplingLeft.Process(
+      *mModelLeft, mInputBufferL.data(), mOutputBufferL.data(), numSamples);
   }
 
   static bool ParseBool(const std::string& value)
@@ -930,7 +928,11 @@ inline void RegisterOptimizedNAMAmpEffect()
     {"presence",              "Presence",           0.0,   -10.0, 10.0,  "dB",  "Tone"},
     {"outputGain",            "Output",             0.0,   -24.0, 24.0,  "dB",  "Level"},
     {"mix",                   "Mix",                1.0,    0.0,   1.0,  "amount", "Advanced", true},
-    {"useCalibration",        "Use Calibration",    1.0,    0.0,   1.0,  "toggle", "Advanced", true}
+    {"useCalibration",        "Use Calibration",    1.0,    0.0,   1.0,  "toggle", "Advanced", true},
+    {"oversampling",          "Oversampling",        0.0,    0.0,   5.0,  "enum", "Advanced", true, 1.0,
+      {"Off", "2x", "4x", "8x", "16x", "32x"}},
+    {"antiAliasPhase",        "AA Filter",           0.0,    0.0,   2.0,  "enum", "Advanced", true, 1.0,
+      {"Minimum Phase", "Linear Short", "Linear Long"}}
   };
 
   EffectRegistry::Instance().Register(info.type, info, []()

--- a/core/src/dsp/effects/OptimizedNAMFXEffect.h
+++ b/core/src/dsp/effects/OptimizedNAMFXEffect.h
@@ -51,7 +51,11 @@ inline void RegisterOptimizedNAMFXEffect()
     {"presence",              "Presence",            0.0,   -10.0, 10.0,  "dB",  "Tone",     true},
     {"outputGain",            "Output",              0.0,   -24.0, 24.0,  "dB",  "Level"},
     {"mix",                   "Mix",                 1.0,    0.0,   1.0,  "amount", "Advanced", true},
-    {"useCalibration",        "Use Calibration",     1.0,    0.0,   1.0,  "toggle", "Advanced", true}
+    {"useCalibration",        "Use Calibration",     1.0,    0.0,   1.0,  "toggle", "Advanced", true},
+    {"oversampling",          "Oversampling",         0.0,    0.0,   5.0,  "enum", "Advanced", true, 1.0,
+      {"Off", "2x", "4x", "8x", "16x", "32x"}},
+    {"antiAliasPhase",        "AA Filter",            0.0,    0.0,   2.0,  "enum", "Advanced", true, 1.0,
+      {"Minimum Phase", "Linear Short", "Linear Long"}}
   };
 
   EffectRegistry::Instance().Register(info.type, info, []()

--- a/core/tests/NamModelCacheTests.cpp
+++ b/core/tests/NamModelCacheTests.cpp
@@ -21,6 +21,8 @@
 
 #include "NAM/dsp.h"
 #include "NAM/get_dsp.h"
+#include "dsp/effects/NAMOversampling.h"
+#include "dsp/effects/NAMSampleRate.h"
 
 namespace fs = std::filesystem;
 namespace cache = guitarfx::nammodelcache;
@@ -211,6 +213,52 @@ namespace
     cache::SetBudgetBytes(originalBudget);
     Check(cache::GetBudgetBytes() == originalBudget, "budget restores");
   }
+
+  void TestOversampledRendering(const fs::path &modelPath)
+  {
+    std::cout << "\n[time-scaled oversampled rendering]\n";
+    auto model = cache::GetModel(modelPath);
+    Check(model != nullptr, "model loads for oversampling");
+    if (!model)
+      return;
+
+    constexpr double fallbackSampleRate = 48000.0;
+    constexpr int blockSize = 64;
+    const double modelSampleRate = guitarfx::ResolveNamModelProcessingSampleRate(
+      model->GetExpectedSampleRate(), fallbackSampleRate);
+    const double hostSampleRate = modelSampleRate;
+
+    guitarfx::NamOversamplingProcessor oversampling;
+    oversampling.Prepare(
+      *model,
+      hostSampleRate,
+      modelSampleRate,
+      blockSize,
+      2,
+      dsp::EAntiAliasFilterPhase::MinimumPhaseCascadedFIR);
+
+    Check(oversampling.GetTimeScale() >= 2, "2x request applies a time-scaled NAM rendering rate");
+    Check(oversampling.GetRenderingSampleRate() > modelSampleRate, "rendering rate exceeds the model rate");
+
+    std::vector<NAM_SAMPLE> input(blockSize);
+    std::vector<NAM_SAMPLE> output(blockSize);
+    bool finite = true;
+    int sampleIndex = 0;
+    for (int block = 0; block < 4; ++block)
+    {
+      for (int i = 0; i < blockSize; ++i, ++sampleIndex)
+      {
+        input[static_cast<std::size_t>(i)] = static_cast<NAM_SAMPLE>(
+          0.1 * std::sin(2.0 * 3.14159265358979323846 * 220.0 * sampleIndex / hostSampleRate));
+      }
+      oversampling.Process(*model, input.data(), output.data(), blockSize);
+      finite = finite && std::all_of(output.begin(), output.end(), [](NAM_SAMPLE sample)
+      {
+        return std::isfinite(static_cast<double>(sample));
+      });
+    }
+    Check(finite, "oversampled real-model output remains finite");
+  }
 } // namespace
 
 int main()
@@ -228,6 +276,7 @@ int main()
   TestEditedFileInvalidates(modelPath);
   TestMissingFileIsHandled();
   TestBudgetEvicts(modelPath);
+  TestOversampledRendering(modelPath);
 
   if (gAllPassed)
     std::cout << "\nNamModelCacheTests passed" << std::endl;

--- a/core/tests/ResourceLoadBenchmark.cpp
+++ b/core/tests/ResourceLoadBenchmark.cpp
@@ -111,7 +111,7 @@ namespace
     // Warm the OS file cache so we measure parse cost, not first-touch disk IO.
     { auto warm = ::nam::get_dsp(path); (void)warm; }
 
-    std::vector<double> fromFile, fromFileNoPrewarm, fromData, dataCopy;
+    std::vector<double> fromFile, fromData, dataCopy;
     ::nam::dspData cached;
     { auto probe = ::nam::get_dsp(path, cached); (void)probe; }
 
@@ -123,13 +123,6 @@ namespace
         fromFile.push_back(MsSince(t));
         if (!model)
           std::cout << "  (null model)\n";
-      }
-      {
-        ::nam::DspLoadOptions options;
-        options.prewarm = false;
-        const auto t = Clock::now();
-        auto model = ::nam::get_dsp(path, options);
-        fromFileNoPrewarm.push_back(MsSince(t));
       }
       {
         // What a dspData cache hit would cost: copy the cached struct (the cache
@@ -162,7 +155,6 @@ namespace
     const double data = Median(fromData);
     PrintRow("Reset(48k, 512)  [prewarm]", Median(resetMs));
     PrintRow("get_dsp(path)  [current, per model]", file);
-    PrintRow("get_dsp(path)  prewarm=false", Median(fromFileNoPrewarm));
     PrintRow("get_dsp(dspData)  [cache hit]", data);
     PrintRow("  of which: dspData struct copy", Median(dataCopy));
     PrintRow("current cost for one node (2x path)", file * 2.0);

--- a/core/tests/SampleRateConverterTests.cpp
+++ b/core/tests/SampleRateConverterTests.cpp
@@ -1,15 +1,70 @@
 #include "dsp/BlockSincResampler.h"
-#include "dsp/effects/NAMSampleRate.h"
+#include "dsp/effects/NAMOversampling.h"
 #include "dsp/effects/NAMSampleRate.h"
 
+#include <atomic>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <new>
 #include <vector>
 
 namespace
 {
+  std::atomic<std::size_t> gAllocationCount {0};
+}
+
+void* operator new(std::size_t size)
+{
+  gAllocationCount.fetch_add(1, std::memory_order_relaxed);
+  if (void* pointer = std::malloc(std::max<std::size_t>(size, 1)))
+    return pointer;
+  throw std::bad_alloc();
+}
+
+void* operator new[](std::size_t size)
+{
+  return ::operator new(size);
+}
+
+void operator delete(void* pointer) noexcept { std::free(pointer); }
+void operator delete[](void* pointer) noexcept { std::free(pointer); }
+void operator delete(void* pointer, std::size_t) noexcept { std::free(pointer); }
+void operator delete[](void* pointer, std::size_t) noexcept { std::free(pointer); }
+
+namespace
+{
   constexpr double kPi = 3.14159265358979323846;
+
+  class TrackingNamDSP final : public ::nam::DSP
+  {
+  public:
+    TrackingNamDSP() : ::nam::DSP(1, 1, 48000.0) {}
+
+    void Reset(double sampleRate, int maxBufferSize) override
+    {
+      resetSampleRate = sampleRate;
+      resetBlockSize = maxBufferSize;
+      ++resetCount;
+    }
+
+    void SetTimeScale(int scale) override { timeScale = scale; }
+
+    void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int numFrames) override
+    {
+      ++processCount;
+      processedFrames += numFrames;
+      std::copy_n(input[0], numFrames, output[0]);
+    }
+
+    double resetSampleRate = 0.0;
+    int resetBlockSize = 0;
+    int resetCount = 0;
+    int timeScale = 0;
+    int processCount = 0;
+    int processedFrames = 0;
+  };
 
   void GenerateSine(std::vector<float>& buffer, double frequency, double sampleRate)
   {
@@ -110,6 +165,115 @@ namespace
     return guitarfx::ResolveNamModelProcessingSampleRate(44100.0, 96000.0) == 44100.0
       && guitarfx::ResolveNamModelProcessingSampleRate(-1.0, 96000.0) == guitarfx::kDefaultNamModelSampleRate;
   }
+
+  bool TestNamOversamplingConfiguration()
+  {
+    return guitarfx::NamOversamplingFactorFromIndex(0.0) == 1
+      && guitarfx::NamOversamplingFactorFromIndex(1.0) == 2
+      && guitarfx::NamOversamplingFactorFromIndex(5.0) == 32
+      && guitarfx::NamOversamplingFactorFromIndex(99.0) == 32
+      && guitarfx::NamOversamplingIndexFromFactor(1) == 0
+      && guitarfx::NamOversamplingIndexFromFactor(8) == 3
+      && guitarfx::ResolveNamOversampledRenderingRate(48000.0, 48000.0, 1) == 48000.0
+      && guitarfx::ResolveNamOversampledRenderingRate(48000.0, 48000.0, 4) == 192000.0
+      && guitarfx::ResolveNamOversampledRenderingRate(48000.0, 44100.0, 2) == 96000.0;
+  }
+
+  bool TestNamDryDelay()
+  {
+    guitarfx::NamDryDelay delay;
+    delay.Prepare(3, 8);
+
+    std::vector<float> firstBlock {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    delay.Process(firstBlock.data(), static_cast<int>(firstBlock.size()));
+    const std::vector<float> expectedFirst {0.0f, 0.0f, 0.0f, 1.0f, 2.0f};
+    if (firstBlock != expectedFirst)
+      return false;
+
+    std::vector<float> secondBlock {6.0f, 7.0f};
+    delay.Process(secondBlock.data(), static_cast<int>(secondBlock.size()));
+    const std::vector<float> expectedSecond {3.0f, 4.0f};
+    if (secondBlock != expectedSecond)
+      return false;
+
+    delay.Reset();
+    std::vector<float> resetBlock {8.0f, 9.0f, 10.0f};
+    delay.Process(resetBlock.data(), static_cast<int>(resetBlock.size()));
+    return resetBlock == std::vector<float>({0.0f, 0.0f, 0.0f});
+  }
+
+  bool TestNamOversamplingProcessor()
+  {
+    constexpr int blockSize = 64;
+    TrackingNamDSP model;
+    guitarfx::NamOversamplingProcessor processor;
+    processor.Prepare(
+      model,
+      48000.0,
+      48000.0,
+      blockSize,
+      4,
+      dsp::EAntiAliasFilterPhase::MinimumPhaseCascadedFIR);
+
+    if (model.timeScale != 4 || model.resetSampleRate != 192000.0 || model.resetBlockSize != 257
+        || processor.GetRenderingSampleRate() != 192000.0 || processor.GetTimeScale() != 4)
+    {
+      return false;
+    }
+
+    std::vector<NAM_SAMPLE> input(blockSize);
+    std::vector<NAM_SAMPLE> output(blockSize, static_cast<NAM_SAMPLE>(0.0));
+    for (int sampleIndex = 0; sampleIndex < blockSize; ++sampleIndex)
+      input[static_cast<std::size_t>(sampleIndex)] = static_cast<NAM_SAMPLE>(sampleIndex) / blockSize;
+
+    const std::size_t allocationsBeforeProcess = gAllocationCount.load(std::memory_order_relaxed);
+    processor.Process(model, input.data(), output.data(), blockSize);
+    const std::size_t allocationsAfterProcess = gAllocationCount.load(std::memory_order_relaxed);
+    if (allocationsAfterProcess != allocationsBeforeProcess)
+      return false;
+    if (model.processCount <= 0 || model.processedFrames < blockSize)
+      return false;
+    for (const NAM_SAMPLE sample : output)
+    {
+      if (!std::isfinite(static_cast<double>(sample)))
+        return false;
+    }
+
+    processor.Reset(model);
+    if (model.resetCount != 2 || model.timeScale != 4)
+      return false;
+
+    TrackingNamDSP linearModel;
+    guitarfx::NamOversamplingProcessor linearProcessor;
+    linearProcessor.Prepare(
+      linearModel,
+      48000.0,
+      48000.0,
+      blockSize,
+      2,
+      dsp::EAntiAliasFilterPhase::LinearCascadedFIRShort);
+    if (linearProcessor.GetLatencySamples() <= 0)
+      return false;
+
+    std::fill(output.begin(), output.end(), static_cast<NAM_SAMPLE>(0.0));
+    const std::size_t allocationsBeforeLinear = gAllocationCount.load(std::memory_order_relaxed);
+    linearProcessor.Process(linearModel, input.data(), output.data(), blockSize);
+    if (gAllocationCount.load(std::memory_order_relaxed) != allocationsBeforeLinear)
+      return false;
+
+    TrackingNamDSP fractionalModel;
+    guitarfx::NamOversamplingProcessor fractionalProcessor;
+    fractionalProcessor.Prepare(
+      fractionalModel,
+      48000.0,
+      44100.0,
+      blockSize,
+      1,
+      dsp::EAntiAliasFilterPhase::MinimumPhaseCascadedFIR);
+    const std::size_t allocationsBeforeFractional = gAllocationCount.load(std::memory_order_relaxed);
+    fractionalProcessor.Process(fractionalModel, input.data(), output.data(), blockSize);
+    return gAllocationCount.load(std::memory_order_relaxed) == allocationsBeforeFractional;
+  }
 }
 
 int main()
@@ -118,6 +282,9 @@ int main()
   const bool fixedOutputOk = TestFixedOutputCount();
   const bool optimizedNamSampleRateParsingOk = TestOptimizedNamSampleRateParsing();
   const bool namDefaultProcessingRateOk = TestNamDefaultProcessingRate();
+  const bool namOversamplingConfigurationOk = TestNamOversamplingConfiguration();
+  const bool namDryDelayOk = TestNamDryDelay();
+  const bool namOversamplingProcessorOk = TestNamOversamplingProcessor();
 
   if (!roundTripOk)
     std::cerr << "Sample-rate converter round-trip quality test failed\n";
@@ -127,6 +294,13 @@ int main()
     std::cerr << "Optimized NAM sample-rate metadata parsing test failed\n";
   if (!namDefaultProcessingRateOk)
     std::cerr << "NAM default processing-rate test failed\n";
+  if (!namOversamplingConfigurationOk)
+    std::cerr << "NAM oversampling configuration test failed\n";
+  if (!namDryDelayOk)
+    std::cerr << "NAM dry-delay alignment test failed\n";
+  if (!namOversamplingProcessorOk)
+    std::cerr << "NAM oversampling processor test failed\n";
 
-  return (roundTripOk && fixedOutputOk && optimizedNamSampleRateParsingOk && namDefaultProcessingRateOk) ? 0 : 1;
+  return (roundTripOk && fixedOutputOk && optimizedNamSampleRateParsingOk && namDefaultProcessingRateOk
+          && namOversamplingConfigurationOk && namDryDelayOk && namOversamplingProcessorOk) ? 0 : 1;
 }

--- a/docs/fx-library.md
+++ b/docs/fx-library.md
@@ -164,14 +164,28 @@ class EffectProcessor {
 ## Built-in Effect Types
 
 ### NAM Amp (`amp_nam`)
-Neural amp model processing.
+Neural amp model processing. The optimized NAM amp, NAM FX, and NAM Blend
+variants share the oversampling controls below.
 
 | Parameter | Range | Default | Unit |
 |-----------|-------|---------|------|
 | `inputGain` | -24..+24 | 0.0 | dB |
 | `outputGain` | -24..+24 | 0.0 | dB |
+| `oversampling` | Off, 2x, 4x, 8x, 16x, 32x | Off | enum |
+| `antiAliasPhase` | Minimum Phase, Linear Short, Linear Long | Minimum Phase | enum |
 
 **Resource**: NAM model file (`.nam`)
+
+Oversampling uses the NAM-Oversampler processing model: the host signal is
+resampled to an integer multiple of the model's native rate, the NAM core's
+temporal convolutions are time-scaled by the same multiple, and the result is
+resampled back to the host rate. This preserves the model's physical receptive
+field instead of shortening its dilations at higher rendering rates.
+
+Minimum Phase is the low-latency real-time default. The linear-phase options
+trade more latency for phase-linear anti-alias filtering; their latency is
+reported to the host and the dry/blended paths are delayed to remain aligned.
+Existing presets remain at Off unless they explicitly set `oversampling`.
 
 ### IR Cabinet (`cab_ir`)
 Impulse response convolution for cabinet simulation.


### PR DESCRIPTION
## Summary

In order to reduce aliasing for NAM models, this adds configurable time-dilated (NAM specific) oversampling to the NAM-based processing blocks:

* Neural Amp (NAM)
* Neural FX (NAM)
* NAM Blend

The Advanced controls provide:

* Oversampling: Off, 2×, 4×, 8×, 16× and 32×
* Anti-alias filter: Minimum Phase, Linear Short and Linear Long

Existing presets remain backward compatible and default to oversampling Off.

## Implementation

The host signal is resampled to an integer multiple of the model’s native rate. NAM temporal convolutions are time-scaled by the same factor so that the model retains approximately the same physical receptive field at the higher rendering rate. The result is then resampled back to the host rate.

The implementation also:

* Reports oversampling latency to the host
* Aligns dry/wet and multi-model blend paths
* Avoids first-block allocations by priming the resampler during preparation
* Adds tests for oversampling factors, filter modes, fractional sample-rate conversion and real NAM processing
* Adds documentation and complete third-party MIT notices

## Attribution

The oversampling approach integrated here was developed by **DLC86** in [[NAM-Oversampler](https://github.com/DLC86/NAM-Oversampler)](https://github.com/DLC86/NAM-Oversampler).

This integration uses pinned revisions of DLC86’s:

* [[NeuralAmpModelerCore](https://github.com/DLC86/NeuralAmpModelerCore)](https://github.com/DLC86/NeuralAmpModelerCore)
* [[AudioDSPTools](https://github.com/DLC86/AudioDSPTools)](https://github.com/DLC86/AudioDSPTools)

Their MIT copyright and license notices are included in `THIRD_PARTY_NOTICES.md`.

## Research background

The NAM-Oversampler author describes the approach as suggested or inspired by the following papers:

* [[Anti-aliasing of neural distortion effects via model fine tuning](https://arxiv.org/abs/2505.11375)](https://arxiv.org/abs/2505.11375)
* [[Sample Rate Independent Recurrent Neural Networks for Audio Effects Processing](https://arxiv.org/abs/2406.06293)](https://arxiv.org/abs/2406.06293)
* [[Resampling Filter Design for Multirate Neural Audio Effect Processing](https://arxiv.org/abs/2501.18470)](https://arxiv.org/abs/2501.18470)
* [[Aliasing Reduction in Neural Amp Modeling by Smoothing Activations](https://arxiv.org/abs/2505.04082)](https://arxiv.org/abs/2505.04082)

## Additional security cleanup

The bundled YouTube API key has been removed. User-configured `jam.youtubeApiKey` values remain supported.

## Testing

* [x] Core Debug build
* [x] `SampleRateConverterTests`
* [x] `NamModelCacheTests`, including a real NAM model at 2×
* [x] Multi-preset mixer tests
* [x] Preset DSP tests
* [x] Stereo processing tests
* [x] macOS Standalone and AU compilation
* [x] Oversampling controls manually verified in the Standalone and AU builds on Mac
* [x] Oversampling alias reduction verified and compared to other plugins with NAM oversampling support

A separate Graphic EQ guide-profile assertion was observed at the end of `EffectProcessorTests`; the NAM wet/dry checks and all effect-processing cases completed successfully before that assertion.

## Screenshots

<img width="507" height="240" alt="Screenshot 2026-08-21 at 9 24 34" src="https://github.com/user-attachments/assets/41b20be0-7ed6-4bf0-8e5c-29890035ce92" />
<img width="2389" height="1278" alt="Screenshot 2026-08-21 at 9 24 03" src="https://github.com/user-attachments/assets/1405173c-7256-4909-a0be-531cb48df74b" />
