### PR TITLE
fix(ui): enable node reordering on Linux (#27) 

### DIFF
--- a/core/ui/css/fx-library.css
+++ b/core/ui/css/fx-library.css
@@ -248,6 +248,15 @@
   transform: scale(0.95);
 }
 
+.fx-item-drag-preview {
+  position: fixed !important;
+  pointer-events: none;
+  margin: 0;
+  opacity: 0.92;
+  transform: translate(-50%, -50%) scale(1.04);
+  z-index: 1000;
+}
+
 .fx-item-icon {
   width: 36px;
   height: 26px;

--- a/core/ui/css/signal-path.css
+++ b/core/ui/css/signal-path.css
@@ -666,6 +666,15 @@ body.signal-path-resizing * {
   z-index: 100;
 }
 
+.signal-node-drag-preview {
+  position: fixed !important;
+  pointer-events: none;
+  margin: 0;
+  opacity: 0.92;
+  transform: translate(-50%, -50%) scale(1.04);
+  z-index: 1000;
+}
+
 .signal-node.drag-over {
   border-color: var(--node-drag-over);
   box-shadow: var(--shadow-md);
@@ -3731,8 +3740,8 @@ body.signal-path-resizing * {
   border: 2px solid #3a3a44;
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
-  max-height: 500px;
-  max-width: 300px;
+  max-height: min(500px, calc(100vh - 16px));
+  max-width: min(300px, calc(100vw - 16px));
   overflow-y: auto;
   z-index: 1000;
   animation: dropdownFadeIn 0.15s ease-out;

--- a/core/ui/ts/fxSelector.ts
+++ b/core/ui/ts/fxSelector.ts
@@ -125,6 +125,21 @@ export type FxLibraryItem = EffectTypeInfo & {
   description?: string;
 };
 
+export type FxPointerDragPayload = {
+  effectType: string;
+  blendId?: string;
+  blendName?: string;
+  blendCategory?: string;
+  customEffect?: {
+    customEffectId: string;
+    name: string;
+    category: string;
+    moduleResourceType: string;
+    moduleResourceId: string;
+    defaultParams: Record<string, number>;
+  };
+};
+
 export interface SignalPathNodeOptions {
   config?: Record<string, string>;
   label?: string;
@@ -390,8 +405,7 @@ function renderFxItem(effect: FxLibraryItem, categoryColor: string): string {
           data-custom-effect-resource-id="${effect.moduleResourceId ?? ""}"
           data-custom-effect-default-params="${effect.customEffectId ? encodeDatasetJson(effect.defaultParams ?? {}) : ""}"
           data-effect-category="${effect.category}"
-         draggable="true"
-         style="--category-color: ${categoryColor}">
+          style="--category-color: ${categoryColor}">
       <div class="fx-item-icon">${(() => { const thumb = effect.blendId ? (getCustomLayout(effect.type, effect.blendId) ?? getCustomLayout(effect.type)) : getCustomLayout(effect.type); const url = thumb?.thumbnailDataUrl ?? effect.thumbnailDataUrl; return url ? `<img src="${url.replace(/"/g, '&quot;')}" alt="" aria-hidden="true" class="fx-item-thumb" />` : getFxEffectIcon(effect.type); })()}</div>
       <div class="fx-item-info">
         <div class="fx-item-name">${effect.displayName}</div>
@@ -459,6 +473,50 @@ function bindFxItemDragHandlers(): void {
     const el = target?.closest(".fx-item") as HTMLElement | null;
     el?.classList.remove("dragging");
     document.body.classList.remove("fx-dragging");
+  });
+
+  fxSelectorEffectsList.addEventListener("pointerdown", (event: PointerEvent) => {
+    if (!event.isPrimary || event.button !== 0) return;
+
+    const target = event.target as HTMLElement | null;
+    const el = target?.closest(".fx-item") as HTMLElement | null;
+    const effectType = el?.dataset.effectType;
+    if (!el || !effectType) return;
+
+    let customEffect: FxPointerDragPayload["customEffect"];
+    const customEffectId = el.dataset.customEffectId;
+    if (customEffectId) {
+      let defaultParams: Record<string, number> = {};
+      try {
+        defaultParams = JSON.parse(decodeURIComponent(el.dataset.customEffectDefaultParams ?? "%7B%7D")) as Record<string, number>;
+      } catch {
+        defaultParams = {};
+      }
+      customEffect = {
+        customEffectId,
+        name: el.querySelector(".fx-item-name")?.textContent ?? "Custom Effect",
+        category: el.dataset.effectCategory ?? "utility",
+        moduleResourceType: el.dataset.customEffectResourceType ?? "",
+        moduleResourceId: el.dataset.customEffectResourceId ?? "",
+        defaultParams,
+      };
+    }
+
+    document.dispatchEvent(new CustomEvent("fx-pointer-drag-start", {
+      detail: {
+        source: el,
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        payload: {
+          effectType,
+          blendId: el.dataset.blendId || undefined,
+          blendName: el.querySelector(".fx-item-name")?.textContent ?? undefined,
+          blendCategory: el.dataset.blendCategory || undefined,
+          customEffect,
+        } satisfies FxPointerDragPayload,
+      },
+    }));
   });
 
   dragDelegationBound = true;

--- a/core/ui/ts/signalPath.ts
+++ b/core/ui/ts/signalPath.ts
@@ -27,9 +27,10 @@ import {
   focusFxSelectorCategory,
   getFxLibraryItems,
   getOrderedFxCategories,
-  sendAddSignalPathNode,
-  sendAddSignalPathNodeOnEdge,
-  type FxLibraryItem,
+    sendAddSignalPathNode,
+    sendAddSignalPathNodeOnEdge,
+    type FxPointerDragPayload,
+    type FxLibraryItem,
   type SignalPathEdgeRef,
   type SignalPathNodeOptions,
 } from "./fxSelector.js";
@@ -921,6 +922,163 @@ function buildCustomEffectNodeOptions(payload: CustomEffectDragPayload): SignalP
     ],
   };
 }
+
+type FxPointerDragTarget =
+  | { kind: "node"; element: HTMLElement; node: GraphNode; preset: Preset }
+  | { kind: "edge"; element: HTMLElement; edge: EdgeRef };
+type FxPointerDrag = {
+  source: HTMLElement;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  payload: FxPointerDragPayload;
+  active: boolean;
+  preview: HTMLElement | null;
+  target: FxPointerDragTarget | null;
+};
+
+let fxPointerDrag: FxPointerDrag | null = null;
+
+function getUiZoomForPointerDrag(): number {
+  const zoom = Number.parseFloat(window.getComputedStyle(document.body).zoom);
+  return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+}
+
+function clearFxPointerDragTarget(target: FxPointerDragTarget | null): void {
+  if (!target) return;
+  target.element.classList.remove("drag-over");
+  if (target.kind === "edge") {
+    target.element.querySelector(".signal-connector")?.classList.remove("drag-over");
+  }
+}
+
+function positionFxPointerDragPreview(preview: HTMLElement, event: PointerEvent): void {
+  const zoom = getUiZoomForPointerDrag();
+  preview.style.left = `${Math.round(event.clientX / zoom)}px`;
+  preview.style.top = `${Math.round(event.clientY / zoom)}px`;
+}
+
+function createFxPointerDragPreview(drag: FxPointerDrag, event: PointerEvent): HTMLElement {
+  const rect = drag.source.getBoundingClientRect();
+  const zoom = getUiZoomForPointerDrag();
+  const preview = drag.source.cloneNode(true) as HTMLElement;
+  preview.classList.remove("dragging");
+  preview.classList.add("fx-item-drag-preview");
+  preview.style.width = `${rect.width / zoom}px`;
+  document.body.appendChild(preview);
+  positionFxPointerDragPreview(preview, event);
+  return preview;
+}
+
+function updateFxPointerDragTarget(event: PointerEvent): void {
+  if (!fxPointerDrag) return;
+
+  const hit = document.elementFromPoint(event.clientX, event.clientY);
+  const nodeElement = hit?.closest<HTMLElement>(".signal-node[data-node-id]");
+  const connector = hit?.closest<HTMLElement>(".signal-connector-wrapper");
+  let target: FxPointerDragTarget | null = null;
+
+  if (nodeElement && signalPathNodesElement?.contains(nodeElement)) {
+    const preset = getSignalPathPreset();
+    const nodeId = nodeElement.dataset.nodeId ?? "";
+    const node = preset?.graph?.nodes.find((candidate) => candidate.id === nodeId);
+    if (node && preset && !isProtectedSignalPathNode(node)) {
+      target = { kind: "node", element: nodeElement, node, preset };
+    }
+  } else if (connector && signalPathNodesElement?.contains(connector)) {
+    const edge = parseEdgeFromDataset(connector);
+    if (edge) target = { kind: "edge", element: connector, edge };
+  }
+
+  if (fxPointerDrag.target?.element === target?.element) return;
+  clearFxPointerDragTarget(fxPointerDrag.target);
+  fxPointerDrag.target = target;
+  if (!target) return;
+
+  target.element.classList.add("drag-over");
+  if (target.kind === "edge") {
+    target.element.querySelector(".signal-connector")?.classList.add("drag-over");
+  }
+}
+
+function finishFxPointerDrag(event: PointerEvent, cancelled = false): void {
+  const drag = fxPointerDrag;
+  if (!drag || drag.pointerId !== event.pointerId) return;
+
+  clearFxPointerDragTarget(drag.target);
+  drag.source.classList.remove("dragging");
+  document.body.classList.remove("fx-dragging");
+  drag.preview?.remove();
+  if (drag.source.hasPointerCapture(event.pointerId)) {
+    drag.source.releasePointerCapture(event.pointerId);
+  }
+  fxPointerDrag = null;
+  if (!drag.active || cancelled || !drag.target) return;
+
+  const customEffect = drag.payload.customEffect;
+  const options = customEffect
+    ? buildCustomEffectNodeOptions({ ...customEffect, baseEffectType: drag.payload.effectType })
+    : {
+        config: drag.payload.blendId ? { blendId: drag.payload.blendId } : undefined,
+        label: drag.payload.blendName,
+        category: drag.payload.blendCategory,
+      };
+
+  if (drag.target.kind === "node") {
+    applyOptimisticNodeReplacement(drag.target.node, drag.payload.effectType, drag.target.preset, options);
+    sendReplaceSignalPathNode(drag.target.node.id, drag.payload.effectType, options);
+    return;
+  }
+
+  sendAddEffectAtEdgeOrFallback(drag.payload.effectType, drag.target.edge, "__input__", options);
+}
+
+document.addEventListener("fx-pointer-drag-start", (event: Event) => {
+  const detail = (event as CustomEvent<{
+    source: HTMLElement;
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    payload: FxPointerDragPayload;
+  }>).detail;
+  if (!detail?.source || !detail.payload.effectType) return;
+
+  fxPointerDrag = {
+    source: detail.source,
+    pointerId: detail.pointerId,
+    startX: detail.clientX,
+    startY: detail.clientY,
+    payload: detail.payload,
+    active: false,
+    preview: null,
+    target: null,
+  };
+  detail.source.setPointerCapture(detail.pointerId);
+});
+
+document.addEventListener("pointermove", (event: PointerEvent) => {
+  if (!fxPointerDrag || fxPointerDrag.pointerId !== event.pointerId) return;
+
+  if (!fxPointerDrag.active) {
+    const distance = Math.hypot(event.clientX - fxPointerDrag.startX, event.clientY - fxPointerDrag.startY);
+    if (distance < 6) return;
+    fxPointerDrag.active = true;
+    fxPointerDrag.source.classList.add("dragging");
+    document.body.classList.add("fx-dragging");
+    fxPointerDrag.preview = createFxPointerDragPreview(fxPointerDrag, event);
+  }
+
+  event.preventDefault();
+  if (fxPointerDrag.preview) positionFxPointerDragPreview(fxPointerDrag.preview, event);
+  updateFxPointerDragTarget(event);
+}, true);
+
+document.addEventListener("pointerup", (event: PointerEvent) => {
+  finishFxPointerDrag(event);
+}, true);
+document.addEventListener("pointercancel", (event: PointerEvent) => {
+  finishFxPointerDrag(event, true);
+}, true);
 
 function applyOptimisticNodeReplacement(
   targetNode: GraphNode,

--- a/core/ui/ts/signalPath.ts
+++ b/core/ui/ts/signalPath.ts
@@ -3473,7 +3473,6 @@ function renderNodeElement(node: GraphNode, options?: RenderNodeElementOptions):
   return `
     <div class="signal-node ${categoryClass} ${bypassedClass} ${selectedClass} ${missingClass}${thumbClass}" 
          data-node-id="${node.id}" 
-         draggable="true" 
          tabindex="0"${nodeTitleAttr}${nodeAriaLabel}>
       ${thumbAvatar}
       ${deleteButton}
@@ -3631,12 +3630,154 @@ function bindNodeClickHandlers(preset: Preset): void {
   // Bind + button click handlers
   bindAddButtonHandlers();
 
+  type PointerDragTarget =
+    | { kind: "node"; element: HTMLElement; nodeId: string }
+    | { kind: "beforeNode"; element: HTMLElement; edge: EdgeRef }
+    | { kind: "edge"; element: HTMLElement; edge: EdgeRef };
+  type NodePointerDrag = {
+    pointerId: number;
+    nodeId: string;
+    source: HTMLElement;
+    startX: number;
+    startY: number;
+    lastX: number;
+    lastY: number;
+    active: boolean;
+    target: PointerDragTarget | null;
+    preview: HTMLElement | null;
+  };
+
+  let pointerDrag: NodePointerDrag | null = null;
+  let suppressNextNodeClickId: string | null = null;
+
+  const getUiZoom = (): number => {
+    const zoom = Number.parseFloat(window.getComputedStyle(document.body).zoom);
+    return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+  };
+
+  const positionPointerDragPreview = (preview: HTMLElement, event: PointerEvent): void => {
+    const uiZoom = getUiZoom();
+    preview.style.left = `${Math.round(event.clientX / uiZoom)}px`;
+    preview.style.top = `${Math.round(event.clientY / uiZoom)}px`;
+  };
+
+  const createPointerDragPreview = (drag: NodePointerDrag, event: PointerEvent): HTMLElement => {
+    const rect = drag.source.getBoundingClientRect();
+    const uiZoom = getUiZoom();
+    const preview = drag.source.cloneNode(true) as HTMLElement;
+    preview.classList.remove("dragging", "drag-over", "selected");
+    preview.classList.add("signal-node-drag-preview");
+    preview.style.width = `${rect.width / uiZoom}px`;
+    preview.style.height = `${rect.height / uiZoom}px`;
+    document.body.appendChild(preview);
+    positionPointerDragPreview(preview, event);
+    return preview;
+  };
+
+  const clearPointerDragTarget = (target: PointerDragTarget | null): void => {
+    if (!target) return;
+    target.element.classList.remove("drag-over");
+    if (target.kind === "edge") {
+      target.element.querySelector(".signal-connector")?.classList.remove("drag-over");
+    }
+  };
+
+  const updatePointerDragTarget = (event: PointerEvent): void => {
+    if (!pointerDrag) return;
+
+    const hit = document.elementFromPoint(event.clientX, event.clientY);
+    const connector = hit?.closest<HTMLElement>(".signal-connector-wrapper");
+    const nodeElement = hit?.closest<HTMLElement>(".signal-node[data-node-id]");
+    let target: PointerDragTarget | null = null;
+
+    if (connector) {
+      const edge = parseEdgeFromDataset(connector);
+      if (edge && edge.from !== pointerDrag.nodeId && edge.to !== pointerDrag.nodeId) {
+        target = { kind: "edge", element: connector, edge };
+      }
+    } else if (nodeElement) {
+      const nodeId = nodeElement.dataset.nodeId ?? "";
+      const node = getGraphNode(nodeId);
+      if (node && nodeId !== pointerDrag.nodeId
+          && node.type !== EffectGuids.kSplitter && node.type !== EffectGuids.kMixer) {
+        const targetIsLeftOfSource = nodeElement.getBoundingClientRect().left
+          < pointerDrag.source.getBoundingClientRect().left;
+        const incomingEdges = (preset.graph?.edges ?? [])
+          .map(normalizeEdge)
+          .filter((edge) => edge.to === nodeId);
+
+        // Reordering onto a node normally inserts after it. For a leftward move,
+        // use its single incoming edge so the dragged node takes the target's slot.
+        if (targetIsLeftOfSource && incomingEdges.length === 1) {
+          target = { kind: "beforeNode", element: nodeElement, edge: incomingEdges[0] };
+        } else {
+          target = { kind: "node", element: nodeElement, nodeId };
+        }
+      }
+    }
+
+    if (pointerDrag.target?.element === target?.element) return;
+    clearPointerDragTarget(pointerDrag.target);
+    pointerDrag.target = target;
+    if (!target) return;
+
+    target.element.classList.add("drag-over");
+    if (target.kind === "edge") {
+      target.element.querySelector(".signal-connector")?.classList.add("drag-over");
+    }
+  };
+
+  const finishPointerDrag = (event: PointerEvent, cancelled = false): void => {
+    const drag = pointerDrag;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+
+    clearPointerDragTarget(drag.target);
+    drag.source.classList.remove("dragging");
+    drag.preview?.remove();
+    if (drag.source.hasPointerCapture(event.pointerId)) {
+      drag.source.releasePointerCapture(event.pointerId);
+    }
+    pointerDrag = null;
+    if (!drag.active || cancelled) return;
+
+    suppressNextNodeClickId = drag.nodeId;
+    window.setTimeout(() => {
+      if (suppressNextNodeClickId === drag.nodeId) suppressNextNodeClickId = null;
+    }, 0);
+
+    if (drag.target?.kind === "edge") {
+      sendMoveSignalPathNodeToEdge(drag.nodeId, drag.target.edge);
+      return;
+    }
+    if (drag.target?.kind === "beforeNode") {
+      sendMoveSignalPathNodeToEdge(drag.nodeId, drag.target.edge);
+      return;
+    }
+    if (drag.target?.kind === "node") {
+      sendSignalPathNodeReorder(drag.nodeId, drag.target.nodeId);
+      return;
+    }
+
+    const node = getGraphNode(drag.nodeId);
+    const deltaX = drag.lastX - drag.startX;
+    const deltaY = drag.lastY - drag.startY;
+    if (node
+        && Math.abs(deltaY) >= NODE_BYPASS_DRAG_DISTANCE_PX
+        && Math.abs(deltaY) > Math.abs(deltaX) * NODE_BYPASS_DRAG_DIRECTION_RATIO) {
+      toggleSignalPathNodeBypass(node, preset);
+    }
+  };
+
   nodeElements.forEach((element) => {
     const el = element as HTMLElement;
     
     // Click handler - select node
     el.addEventListener("click", () => {
       const nodeId = el.dataset.nodeId;
+      if (nodeId && suppressNextNodeClickId === nodeId) {
+        suppressNextNodeClickId = null;
+        return;
+      }
       if (nodeId && preset.graph) {
         const node = preset.graph.nodes.find((n) => n.id === nodeId);
         if (node) {
@@ -3674,6 +3815,60 @@ function bindNodeClickHandlers(preset: Preset): void {
         expand: true,
         clearSearch: true,
       });
+    });
+
+    el.addEventListener("pointerdown", (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0
+          || (event.target instanceof Element && event.target.closest("button, input, select, textarea"))) {
+        return;
+      }
+
+      const nodeId = el.dataset.nodeId ?? "";
+      const node = getGraphNode(nodeId);
+      if (!node || node.type === EffectGuids.kSplitter || node.type === EffectGuids.kMixer) {
+        return;
+      }
+
+      pointerDrag = {
+        pointerId: event.pointerId,
+        nodeId,
+        source: el,
+        startX: event.clientX,
+        startY: event.clientY,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        active: false,
+        target: null,
+        preview: null,
+      };
+      el.setPointerCapture(event.pointerId);
+    });
+
+    el.addEventListener("pointermove", (event: PointerEvent) => {
+      if (!pointerDrag || pointerDrag.pointerId !== event.pointerId) return;
+
+      pointerDrag.lastX = event.clientX;
+      pointerDrag.lastY = event.clientY;
+      if (!pointerDrag.active) {
+        const distance = Math.hypot(event.clientX - pointerDrag.startX, event.clientY - pointerDrag.startY);
+        if (distance < 6) return;
+        pointerDrag.active = true;
+        pointerDrag.source.classList.add("dragging");
+        pointerDrag.preview = createPointerDragPreview(pointerDrag, event);
+      }
+
+      event.preventDefault();
+      if (pointerDrag.preview) {
+        positionPointerDragPreview(pointerDrag.preview, event);
+      }
+      updatePointerDragTarget(event);
+    });
+
+    el.addEventListener("pointerup", (event: PointerEvent) => {
+      finishPointerDrag(event);
+    });
+    el.addEventListener("pointercancel", (event: PointerEvent) => {
+      finishPointerDrag(event, true);
     });
     
     // Drag start
@@ -3860,22 +4055,19 @@ function bindConnectorDropHandlers(preset: Preset): void {
     // Drag over
     el.addEventListener("dragover", (e: DragEvent) => {
       e.preventDefault();
-      updateNodeDragPoint(e);
       
       // Only accept drops from FX library
       const fxEffectType = Array.from(e.dataTransfer?.types ?? []).includes("application/x-fx-effect");
       const fxBlendType = Array.from(e.dataTransfer?.types ?? []).includes("application/x-fx-blend");
       const fxCustomEffectType = Array.from(e.dataTransfer?.types ?? []).includes("application/x-fx-custom-effect");
       const fxResourceGroup = Array.from(e.dataTransfer?.types ?? []).includes("application/x-resource-group");
-      const signalNodeId = e.dataTransfer?.getData("application/x-signal-node") || "";
-      const isSignalNode = Boolean(signalNodeId);
       
-      if (fxEffectType || fxBlendType || fxCustomEffectType || fxResourceGroup || isSignalNode) {
+      if (fxEffectType || fxBlendType || fxCustomEffectType || fxResourceGroup) {
         const connector = el.querySelector(".signal-connector") as HTMLElement | null;
         connector?.classList.add("drag-over");
         el.classList.add("drag-over");
         if (e.dataTransfer) {
-          e.dataTransfer.dropEffect = (fxEffectType || fxBlendType || fxCustomEffectType || fxResourceGroup) ? "copy" : "move";
+          e.dataTransfer.dropEffect = "copy";
         }
       }
     });
@@ -3890,14 +4082,12 @@ function bindConnectorDropHandlers(preset: Preset): void {
     // Drop
     el.addEventListener("drop", (e: DragEvent) => {
       e.preventDefault();
-      updateNodeDragPoint(e);
       const fxEffectType = e.dataTransfer?.getData("application/x-fx-effect");
       const fxBlendId = e.dataTransfer?.getData("application/x-fx-blend");
       const fxBlendName = e.dataTransfer?.getData("application/x-fx-blend-name");
       const fxBlendCategory = e.dataTransfer?.getData("application/x-fx-blend-category");
       const customEffectPayloadRaw = e.dataTransfer?.getData("application/x-fx-custom-effect");
       const resourceGroupPayload = e.dataTransfer?.getData("application/x-resource-group");
-      const signalNodeId = e.dataTransfer?.getData("application/x-signal-node");
 
       const edge = parseEdgeFromDataset(el);
       if (resourceGroupPayload && preset.graph) {
@@ -3922,12 +4112,6 @@ function bindConnectorDropHandlers(preset: Preset): void {
           label: fxBlendName || undefined,
           category: fxBlendCategory || undefined,
         });
-      } else if (signalNodeId && edge && preset.graph) {
-        const node = preset.graph.nodes.find((n) => n.id === signalNodeId);
-        if (node && node.type !== EffectGuids.kSplitter && node.type !== EffectGuids.kMixer) {
-          nodeDragDropHandled = true;
-          sendMoveSignalPathNodeToEdge(signalNodeId, edge);
-        }
       }
       
       const connector = el.querySelector(".signal-connector") as HTMLElement | null;
@@ -7528,10 +7712,41 @@ function showEffectSelectionDropdown(buttonElement: HTMLElement, edge: EdgeRef |
   dropdown.innerHTML = dropdownHtml;
   document.body.appendChild(dropdown);
 
-  // Position dropdown near the button
-  const buttonRect = buttonElement.getBoundingClientRect();
-  dropdown.style.left = `${buttonRect.left}px`;
-  dropdown.style.top = `${buttonRect.bottom + 5}px`;
+  const positionDropdown = (): void => {
+    const buttonRect = buttonElement.getBoundingClientRect();
+    const margin = 8;
+    const appliedZoom = Number.parseFloat(window.getComputedStyle(document.body).zoom);
+    const uiZoom = Number.isFinite(appliedZoom) && appliedZoom > 0 ? appliedZoom : 1;
+    const viewportWidth = window.innerWidth / uiZoom;
+    const viewportHeight = window.innerHeight / uiZoom;
+
+    dropdown.style.maxWidth = `${Math.min(300, viewportWidth - margin * 2)}px`;
+    dropdown.style.maxHeight = `${Math.min(500, viewportHeight - margin * 2)}px`;
+    const dropdownWidth = dropdown.offsetWidth;
+    const dropdownHeight = dropdown.offsetHeight;
+    const left = Math.max(
+      margin,
+      Math.min(buttonRect.left / uiZoom, viewportWidth - dropdownWidth - margin),
+    );
+    let top = buttonRect.bottom / uiZoom + 5;
+
+    if (top + dropdownHeight > viewportHeight - margin) {
+      top = Math.max(margin, buttonRect.top / uiZoom - dropdownHeight - 5);
+    }
+
+    dropdown.style.left = `${Math.round(left)}px`;
+    dropdown.style.top = `${Math.round(top)}px`;
+  };
+
+  const closeDropdown = (): void => {
+    window.removeEventListener("resize", positionDropdown);
+    window.removeEventListener("scroll", positionDropdown, true);
+    dropdown.remove();
+  };
+
+  positionDropdown();
+  window.addEventListener("resize", positionDropdown);
+  window.addEventListener("scroll", positionDropdown, true);
 
   // Bind effect selection
   const effectItems = dropdown.querySelectorAll(".effect-dropdown-item");
@@ -7561,7 +7776,7 @@ function showEffectSelectionDropdown(buttonElement: HTMLElement, edge: EdgeRef |
             category: blendCategory || undefined,
           });
         }
-        dropdown.remove();
+        closeDropdown();
       }
     });
   });
@@ -7570,7 +7785,7 @@ function showEffectSelectionDropdown(buttonElement: HTMLElement, edge: EdgeRef |
   setTimeout(() => {
     const closeHandler = (e: MouseEvent) => {
       if (!dropdown.contains(e.target as Node)) {
-        dropdown.remove();
+        closeDropdown();
         document.removeEventListener("click", closeHandler);
       }
     };

--- a/core/ui/ui-components/fx-selector-panel.html
+++ b/core/ui/ui-components/fx-selector-panel.html
@@ -37,8 +37,7 @@
                 :data-custom-effect-resource-id="fx.moduleResourceId || ''"
                 :data-custom-effect-default-params="fx.customEffectDefaultParams || ''"
                 :data-effect-category="fx.category || ''"
-                :style="`--category-color: ${fx.categoryColor || '#808080'}`"
-                draggable="true">
+                :style="`--category-color: ${fx.categoryColor || '#808080'}`">
                 <div class="fx-item-icon"></div>
                 <div class="fx-item-info">
                   <div class="fx-item-name" x-text="fx.displayName || fx.name || fx.title || ''"></div>


### PR DESCRIPTION
Sorry, I don't have knowledge on webapp development so I coded this fix with AI (GPT-5.6 and OpenCode).
It fix Issue #27 on Linux. I tested it on my Linux Arch laptop and seems to work.

But I can't guarantee it will work on Windows and Mac, or whether it's the best way to resolve the issue.

Anyway, this problem was quite frustrating on Linux, so I tried a workaround. Of course, feel free to reject this AI implementation.

### Summary
Replaced native HTML5 drag-and-drop for signal-chain node reordering with pointer-based interactions.

### Why
WebKitGTK on Linux starts HTML5 dragging but does not emit the required drop event on signal-chain targets. This prevented node reordering even though the drag visual appeared to work. WebView2/Chromium does not exhibit this issue.


### What Changed
- Removed native draggable behavior from signal nodes.
- Added pointer-driven reorder handling using pointerdown, pointermove, pointerup, and pointercancel.
- Uses elementFromPoint() to resolve a target node or connector while dragging.
- Reuses the existing reorderSignalPathNode backend message and graph mutation path.
- Added a drag-preview ghost that follows the pointer without blocking hit-testing.
- Preserved vertical drag to toggle node bypass.
- Preserved native HTML5 drop support for external FX-library items and resource files.
- Improved leftward reordering: dropping onto a node to the left inserts before it, while rightward movement preserves insertion after the target.