### PR TITLE
Fix installer component checkbox toggle behavior

### DIFF
--- a/juce/packaging/installer.iss
+++ b/juce/packaging/installer.iss
@@ -25,8 +25,8 @@ Name: "custom"; Description: "Custom installation"; Flags: iscustom
 
 ; Components are used inside the script and can be composed of a set of 'Types'
 [Components]
-Name: "standalone"; Description: "Standalone application"; Types: full custom
-Name: "vst3"; Description: "VST3 plugin"; Types: full custom
+Name: "standalone"; Description: "Standalone application"; Types: full custom; Flags: checkablealone
+Name: "vst3"; Description: "VST3 plugin"; Types: full custom; Flags: checkablealone
 Name: "clap"; Description: "CLAP plugin"; Types: custom; Flags: checkablealone
 
 [Setup]
@@ -175,6 +175,19 @@ end;
 function NextButtonClick(CurPageID: Integer): Boolean;
 begin
     Result := True;
+
+    if CurPageID = wpSelectComponents then
+    begin
+        if not WizardIsComponentSelected('standalone')
+            and not WizardIsComponentSelected('vst3')
+            and not WizardIsComponentSelected('clap') then
+        begin
+            MsgBox('Select at least one component to install.', mbError, MB_OK);
+            Result := False;
+        end;
+
+        Exit;
+    end;
 
     if CurPageID <> InstallPathsPage.ID then
         Exit;


### PR DESCRIPTION
Closes #40 

This pull request improves the installer experience by ensuring users select at least one component before proceeding and by adjusting component selection behavior for standalone and VST3 plugins. The main changes are:

**Installer behavior improvements:**

* Added a check on the component selection page to require users to select at least one component (`standalone`, `vst3`, or `clap`) before continuing. If none are selected, an error message is shown and the user cannot proceed.

**Component selection configuration:**

* Updated the `standalone` and `vst3` components in the installer configuration to include the `checkablealone` flag, making them independently selectable and improving the selection logic.